### PR TITLE
팝업 상세 정보 크롤링 및 저장 기능 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,6 +62,9 @@ dependencies {
 	annotationProcessor("org.mapstruct:mapstruct-processor:1.5.5.Final")
 	annotationProcessor("org.projectlombok:lombok-mapstruct-binding:0.2.0")
 
+	// Jsoup for HTML parsing
+	implementation("org.jsoup:jsoup:1.19.1")
+
 	// REST Docs
 	testImplementation("org.springframework.restdocs:spring-restdocs-webtestclient")
 	// 테스트

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,8 +62,11 @@ dependencies {
 	annotationProcessor("org.mapstruct:mapstruct-processor:1.5.5.Final")
 	annotationProcessor("org.projectlombok:lombok-mapstruct-binding:0.2.0")
 
-	// Jsoup for HTML parsing
+	// for crawling
 	implementation("org.jsoup:jsoup:1.19.1")
+	implementation("org.seleniumhq.selenium:selenium-java:4.31.0")
+	implementation("io.github.bonigarcia:webdrivermanager:5.8.0")
+	implementation("org.apache.httpcomponents.client5:httpclient5:5.3.1")
 
 	// REST Docs
 	testImplementation("org.springframework.restdocs:spring-restdocs-webtestclient")

--- a/src/main/kotlin/com/wheretopop/application/popup/PopupExternalUseCases.kt
+++ b/src/main/kotlin/com/wheretopop/application/popup/PopupExternalUseCases.kt
@@ -1,0 +1,5 @@
+package com.wheretopop.application.popup
+
+interface PopupPopplyUseCase {
+    suspend fun crawlPopplyAndSave()
+}

--- a/src/main/kotlin/com/wheretopop/application/popup/PopupFacade.kt
+++ b/src/main/kotlin/com/wheretopop/application/popup/PopupFacade.kt
@@ -1,0 +1,22 @@
+package com.wheretopop.application.popup
+
+import com.wheretopop.domain.popup.PopupService
+import org.springframework.stereotype.Service
+
+/**
+ * Popup 애플리케이션 서비스
+ * 컨트롤러와 도메인 서비스 사이의 퍼사드 역할
+ */
+@Service
+class PopupFacade(
+    private val popupService: PopupService,
+    private val popupPopplyUseCase: PopupPopplyUseCase
+) {
+    /**
+     * 무슨 메서드가 필요할까?
+     */
+
+    suspend fun ingestPopupExternalData() {
+        return popupPopplyUseCase.crawlPopplyAndSave()
+    }
+}

--- a/src/main/kotlin/com/wheretopop/config/R2dbcConfig.kt
+++ b/src/main/kotlin/com/wheretopop/config/R2dbcConfig.kt
@@ -6,6 +6,12 @@ import com.wheretopop.infrastructure.area.R2dbcAreaRepository
 import com.wheretopop.infrastructure.area.external.opendata.population.AreaPopulationIdToLongConverter
 import com.wheretopop.infrastructure.area.external.opendata.population.LongToAreaPopulationIdConverter
 import com.wheretopop.infrastructure.area.external.opendata.population.R2dbcAreaPopulationRepository
+import com.wheretopop.infrastructure.popup.LongToPopupIdConverter
+import com.wheretopop.infrastructure.popup.PopupIdToLongConverter
+import com.wheretopop.infrastructure.popup.R2dbcPopupRepository
+import com.wheretopop.infrastructure.popup.external.popply.LongToPopupPopplyIdConverter
+import com.wheretopop.infrastructure.popup.external.popply.PopupPopplyIdToLongConverter
+import com.wheretopop.infrastructure.popup.external.popply.R2dbcPopupPopplyRepository
 import io.r2dbc.spi.ConnectionFactory
 import org.mariadb.r2dbc.MariadbConnectionConfiguration
 import org.mariadb.r2dbc.MariadbConnectionFactory
@@ -60,7 +66,9 @@ class R2dbcConfig : AbstractR2dbcConfiguration() {
     override fun getCustomConverters(): MutableList<Any> = mutableListOf(
         AreaIdToLongConverter(), LongToAreaIdConverter(),
         AreaPopulationIdToLongConverter(), LongToAreaPopulationIdConverter(),
-        InstantToLocalDateTimeConverter(), LocalDateTimeToInstantConverter()
+        InstantToLocalDateTimeConverter(), LocalDateTimeToInstantConverter(),
+        PopupIdToLongConverter(), LongToPopupIdConverter(),
+        PopupPopplyIdToLongConverter(), LongToPopupPopplyIdConverter()
     )
 
 
@@ -73,6 +81,11 @@ class R2dbcConfig : AbstractR2dbcConfiguration() {
     internal fun r2dbcAreaRepository(template: R2dbcEntityTemplate) = R2dbcAreaRepository(template)
     @Bean
     internal fun r2dbcAreaPopulationRepository(template: R2dbcEntityTemplate) = R2dbcAreaPopulationRepository(template)
+
+    @Bean
+    internal fun r2dbcPopupRepository(template: R2dbcEntityTemplate) = R2dbcPopupRepository(template)
+    @Bean
+    internal fun r2dbcPopupPopplyRepository(template: R2dbcEntityTemplate) = R2dbcPopupPopplyRepository(template)
 
 }
 

--- a/src/main/kotlin/com/wheretopop/config/WebClientConfig.kt
+++ b/src/main/kotlin/com/wheretopop/config/WebClientConfig.kt
@@ -13,4 +13,11 @@
                 .baseUrl("http://openapi.seoul.go.kr:8088")
                 .build()
         }
+
+        @Bean
+        fun popupApiWebClient(): WebClient {
+            return WebClient.builder()
+                .baseUrl("https://www.popply.co.kr/popup")
+                .build()
+        }
     }

--- a/src/main/kotlin/com/wheretopop/config/WebDriverConfig.kt
+++ b/src/main/kotlin/com/wheretopop/config/WebDriverConfig.kt
@@ -1,0 +1,51 @@
+package com.wheretopop.config
+
+import io.github.bonigarcia.wdm.WebDriverManager
+import org.openqa.selenium.WebDriver
+import org.openqa.selenium.chrome.ChromeDriver
+import org.openqa.selenium.chrome.ChromeOptions
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class WebDriverConfig {
+
+    // Chrome 옵션 설정을 위한 프로퍼티 값 주입 (application.yml/properties 에서 설정)
+    @Value("\${selenium.chrome.headless:true}")
+    private var headless: Boolean = true
+
+    @Value("\${selenium.chrome.arguments:--disable-gpu,--no-sandbox,--disable-dev-shm-usage}") // 기본 인자값
+    private lateinit var chromeArguments: List<String>
+
+    /**
+     * ChromeOptions Bean 설정
+     * 필요한 Chrome 브라우저 실행 옵션을 설정합니다.
+     */
+    @Bean
+    fun chromeOptions(): ChromeOptions {
+        val options = ChromeOptions()
+        if (headless) {
+            options.addArguments("--headless")
+        }
+        options.addArguments(chromeArguments)
+        return options
+    }
+
+    /**
+     * WebDriver Bean 설정
+     * - chromeOptions Bean을 주입받아 사용합니다.
+     * - WebDriverManager를 통해 ChromeDriver를 설정합니다.
+     * - Spring이 Bean을 소멸시킬 때(애플리케이션 종료 등) 자동으로 driver.quit()를 호출하도록 destroyMethod 설정합니다.
+     * - 기본적으로 Singleton 스코프로 생성
+     */
+    @Bean(destroyMethod = "quit") // Bean 소멸 시 quit 메소드 자동 호출
+    fun chromeDriver(chromeOptions: ChromeOptions): WebDriver {
+        WebDriverManager.chromedriver().setup()
+        val driver = ChromeDriver(chromeOptions)
+        return driver
+        // 참고: 만약 여러 요청이 동시에 이 드라이버를 사용한다면 스레드 안전성 문제가 발생할 수 있음
+        // 동시성 문제가 우려된다면 WebDriver Pooling 등을 고려해야 함
+        // 기본적인 스케줄러 기반의 단일 스크래핑 작업 등에는 Singleton 스코프가 효율적
+    }
+}

--- a/src/main/kotlin/com/wheretopop/domain/popup/Popup.kt
+++ b/src/main/kotlin/com/wheretopop/domain/popup/Popup.kt
@@ -1,0 +1,30 @@
+package com.wheretopop.domain.popup
+
+import java.time.Instant
+
+class Popup private constructor(
+    val id: PopupId,
+    val name: String,
+    val address: String,
+    val createdAt: Instant,
+    var deletedAt: Instant? = null
+) {
+    companion object {
+        fun create(
+            id: PopupId = PopupId.create(),
+            name: String,
+            address: String,
+            createdAt: Instant = Instant.now(),
+            deletedAt: Instant? = null
+        ): Popup {
+            require(name.isNotBlank()) {"팝업 이름은 필수입니다."}
+            return Popup(
+                id = id,
+                name = name,
+                address = address,
+                createdAt = createdAt,
+                deletedAt = deletedAt
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/wheretopop/domain/popup/PopupId.kt
+++ b/src/main/kotlin/com/wheretopop/domain/popup/PopupId.kt
@@ -1,0 +1,19 @@
+package com.wheretopop.domain.popup
+
+import com.wheretopop.shared.model.UniqueId
+
+class PopupId private constructor(
+    value: Long
+) : UniqueId(value) {
+    companion object {
+        @JvmStatic
+        fun create(): PopupId {
+            return PopupId(UniqueId.create().value)
+        }
+
+        @JvmStatic
+        fun of(value: Long): PopupId {
+            return PopupId(UniqueId.of(value).value)
+        }
+    }
+}

--- a/src/main/kotlin/com/wheretopop/domain/popup/PopupReader.kt
+++ b/src/main/kotlin/com/wheretopop/domain/popup/PopupReader.kt
@@ -1,0 +1,7 @@
+package com.wheretopop.domain.popup
+
+interface PopupReader {
+    suspend fun findAll(): List<Popup>
+    suspend fun findById(id: PopupId): Popup?
+    suspend fun findByName(name: String): Popup?
+}

--- a/src/main/kotlin/com/wheretopop/domain/popup/PopupServiceImpl.kt
+++ b/src/main/kotlin/com/wheretopop/domain/popup/PopupServiceImpl.kt
@@ -1,0 +1,7 @@
+package com.wheretopop.domain.popup
+
+import org.springframework.stereotype.Service
+
+@Service
+class PopupServiceImpl(): PopupService {
+}

--- a/src/main/kotlin/com/wheretopop/domain/popup/PopupStore.kt
+++ b/src/main/kotlin/com/wheretopop/domain/popup/PopupStore.kt
@@ -1,0 +1,8 @@
+package com.wheretopop.domain.popup
+
+interface PopupStore {
+    suspend fun save(popup: Popup): Popup
+    suspend fun save(popups: List<Popup>): List<Popup>
+    suspend fun delete(popup: Popup)
+    suspend fun delete(popups: List<Popup>)
+}

--- a/src/main/kotlin/com/wheretopop/infrastructure/popup/PopupEntity.kt
+++ b/src/main/kotlin/com/wheretopop/infrastructure/popup/PopupEntity.kt
@@ -1,137 +1,79 @@
 package com.wheretopop.infrastructure.popup
 
-import com.wheretopop.shared.enums.PopUpCategory
-import com.wheretopop.shared.enums.PopUpType
+import com.wheretopop.domain.popup.Popup
+import com.wheretopop.domain.popup.PopupId
+import org.springframework.core.convert.converter.Converter
 import org.springframework.data.annotation.Id
+import org.springframework.data.convert.ReadingConverter
+import org.springframework.data.convert.WritingConverter
 import org.springframework.data.relational.core.mapping.Column
 import org.springframework.data.relational.core.mapping.Table
-import java.time.ZonedDateTime
+import java.time.Instant
 
 @Table("popups")
 data class PopupEntity(
     @Id
     @Column("id")
-    val id: Long,
+    val id: PopupId,
 
     @Column("name")
     val name: String,
 
-    @Column("building_id")
-    val buildingId: Long?,
-
-    @Column("start_time")
-    val startTime: ZonedDateTime?,
-
-    @Column("end_time")
-    val endTime: ZonedDateTime?,
-
-    @Column("category")
-    val category: PopUpCategory?,
-    
-    @Column("type")
-    val type: PopUpType?,
-
-    @Column("description")
-    val description: String?,
-
-    @Column("brand_name")
-    val brandName: String?,
-        
-    @Column("visitor_count")
-    val visitorCount: Int?,
-        
-    @Column("visitor_age_group")
-    val visitorAgeGroup: String?,
-        
-    @Column("visitor_gender_ratio")
-    val visitorGenderRatio: String?,
-        
-    @Column("news_mention_count")
-    val newsMentionCount: Int?,
-        
-    @Column("hashtag_usage_count")
-    val hashtagUsageCount: Int?,
-        
-    @Column("keyword_search_count")
-    val keywordSearchCount: Int?,
-        
-    @Column("positive_review_ratio")
-    val positiveReviewRatio: Double?,
+//    @Column("building_id")
+//    val buildingId: Long?,
+    @Column("address")
+    val address : String,
 
     @Column("created_at")
-    val createdAt: ZonedDateTime,
-
-    @Column("updated_at")
-    val updatedAt: ZonedDateTime,
+    val createdAt: Instant,
 
     @Column("deleted_at")
-    val deletedAt: ZonedDateTime?
+    val deletedAt: Instant?,
+
 ) {
-//    companion object {
-//        fun of(popup: Popup): PopupEntity {
-//            return PopupEntity(
-//                id = popup.id.toLong(),
-//                name = popup.name,
-//                buildingId = popup.buildingId,
-//                startTime = popup.startTime,
-//                endTime = popup.endTime,
-//                category = popup.category,
-//                type = popup.type,
-//                description = popup.description,
-//                brandName = popup.brandName,
-//                visitorCount = popup.visitorCount,
-//                visitorAgeGroup = popup.visitorAgeGroup,
-//                visitorGenderRatio = popup.visitorGenderRatio,
-//                newsMentionCount = popup.newsMentionCount,
-//                hashtagUsageCount = popup.hashtagUsageCount,
-//                keywordSearchCount = popup.keywordSearchCount,
-//                positiveReviewRatio = popup.positiveReviewRatio,
-//                createdAt = popup.createdAt,
-//                updatedAt = popup.updatedAt,
-//                deletedAt = popup.deletedAt
-//            )
-//        }
-//    }
-//
-//    fun toDomain(): Popup {
-//        return Popup.create(
-//            id = UniqueId.of(id),
-//            name = name,
+    companion object {
+        fun of(popup: Popup): PopupEntity {
+            return PopupEntity(
+                id = popup.id,
+                name = popup.name,
+    //            buildingId = buildingId,
+                address = popup.address,
+                createdAt = popup.createdAt,
+                deletedAt = popup.deletedAt,
+            )
+        }
+    }
+
+    fun toDomain(): Popup {
+        return Popup.create(
+            id = id,
+            name = name,
 //            buildingId = buildingId,
-//            startTime = startTime,
-//            endTime = endTime,
-//            category = category,
-//            type = type,
-//            description = description,
-//            brandName = brandName,
-//            visitorCount = visitorCount,
-//            visitorAgeGroup = visitorAgeGroup,
-//            visitorGenderRatio = visitorGenderRatio,
-//            newsMentionCount = newsMentionCount,
-//            hashtagUsageCount = hashtagUsageCount,
-//            keywordSearchCount = keywordSearchCount,
-//            positiveReviewRatio = positiveReviewRatio
-//        )
-//    }
-//
-//    fun update(popup: Popup): PopupEntity {
-//        return copy(
-//            name = popup.name,
+            address = address,
+            createdAt = createdAt,
+            deletedAt = deletedAt,
+        )
+    }
+
+    fun update(popup: Popup): PopupEntity {
+        return PopupEntity(
+            id = id,
+            name = popup.name,
 //            buildingId = popup.buildingId,
-//            startTime = popup.startTime,
-//            endTime = popup.endTime,
-//            category = popup.category,
-//            type = popup.type,
-//            description = popup.description,
-//            brandName = popup.brandName,
-//            visitorCount = popup.visitorCount,
-//            visitorAgeGroup = popup.visitorAgeGroup,
-//            visitorGenderRatio = popup.visitorGenderRatio,
-//            newsMentionCount = popup.newsMentionCount,
-//            hashtagUsageCount = popup.hashtagUsageCount,
-//            keywordSearchCount = popup.keywordSearchCount,
-//            positiveReviewRatio = popup.positiveReviewRatio,
-//            updatedAt = ZonedDateTime.now()
-//        )
-//    }
+            address = popup.address,
+            createdAt = createdAt,
+            deletedAt = deletedAt,
+        )
+    }
+}
+
+@WritingConverter
+class PopupIdToLongConverter : Converter<PopupId, Long> {
+    override fun convert(source: PopupId) = source.toLong()
+}
+
+
+@ReadingConverter
+class LongToPopupIdConverter : Converter<Long, PopupId> {
+    override fun convert(source: Long) = PopupId.of(source)
 }

--- a/src/main/kotlin/com/wheretopop/infrastructure/popup/PopupReaderImpl.kt
+++ b/src/main/kotlin/com/wheretopop/infrastructure/popup/PopupReaderImpl.kt
@@ -1,0 +1,24 @@
+package com.wheretopop.infrastructure.popup
+
+import com.wheretopop.domain.popup.Popup
+import com.wheretopop.domain.popup.PopupId
+import com.wheretopop.domain.popup.PopupReader
+import org.springframework.stereotype.Component
+
+@Component
+class PopupReaderImpl(
+    private val popupRepository: PopupRepository
+) : PopupReader {
+
+    override suspend fun findAll(): List<Popup> {
+        return popupRepository.findAll()
+    }
+
+    override suspend fun findById(id: PopupId): Popup? {
+        return popupRepository.findById(id)
+    }
+
+    override suspend fun findByName(name: String): Popup? {
+        return popupRepository.findByName(name)
+    }
+}

--- a/src/main/kotlin/com/wheretopop/infrastructure/popup/PopupRepository.kt
+++ b/src/main/kotlin/com/wheretopop/infrastructure/popup/PopupRepository.kt
@@ -1,0 +1,13 @@
+package com.wheretopop.infrastructure.popup
+
+import com.wheretopop.domain.popup.Popup
+import com.wheretopop.domain.popup.PopupId
+
+interface PopupRepository {
+    suspend fun findById(id: PopupId): Popup?
+    suspend fun findByName(name: String): Popup?
+    suspend fun findAll(): List<Popup>
+    suspend fun save(popup: Popup): Popup
+    suspend fun save(popups: List<Popup>): List<Popup>
+    suspend fun deleteById(id: PopupId)
+}

--- a/src/main/kotlin/com/wheretopop/infrastructure/popup/PopupStoreImpl.kt
+++ b/src/main/kotlin/com/wheretopop/infrastructure/popup/PopupStoreImpl.kt
@@ -1,0 +1,26 @@
+package com.wheretopop.infrastructure.popup
+
+import com.wheretopop.domain.popup.Popup
+import com.wheretopop.domain.popup.PopupStore
+import org.springframework.stereotype.Component
+
+@Component
+class PopupStoreImpl(
+    private val popupRepository: PopupRepository
+) : PopupStore {
+
+    override suspend fun save(popup: Popup): Popup {
+        return popupRepository.save(popup)
+    }
+    override suspend fun save(popups: List<Popup>): List<Popup> {
+        return popupRepository.save(popups)
+    }
+    override suspend fun delete(popup: Popup) {
+        popupRepository.deleteById(popup.id)
+    }
+    override suspend fun delete(popups: List<Popup>) {
+        popups.forEach { popup ->
+            popupRepository.deleteById(popup.id)
+        }
+    }
+}

--- a/src/main/kotlin/com/wheretopop/infrastructure/popup/R2dbcPopupRepository.kt
+++ b/src/main/kotlin/com/wheretopop/infrastructure/popup/R2dbcPopupRepository.kt
@@ -1,0 +1,55 @@
+package com.wheretopop.infrastructure.popup
+
+import com.wheretopop.domain.popup.Popup
+import com.wheretopop.domain.popup.PopupId
+import kotlinx.coroutines.reactor.awaitSingle
+import kotlinx.coroutines.reactor.awaitSingleOrNull
+import org.springframework.data.r2dbc.core.R2dbcEntityTemplate
+import org.springframework.data.relational.core.query.Criteria.where
+import org.springframework.data.relational.core.query.Query.query
+
+internal class R2dbcPopupRepository(
+    private val entityTemplate: R2dbcEntityTemplate
+) : PopupRepository {
+
+    private val entityClass = PopupEntity::class.java
+
+    override suspend fun findById(id: PopupId): Popup? =
+        loadEntityById(id)?.toDomain()
+
+    override suspend fun findByName(name: String): Popup? =
+        entityTemplate
+            .selectOne(query(where("name").`is`(name)), entityClass)
+            .awaitSingleOrNull()
+            ?.toDomain()
+
+    override suspend fun findAll(): List<Popup> =
+        entityTemplate.select(entityClass)
+            .all()
+            .map { it.toDomain() }
+            .collectList()
+            .awaitSingle()
+
+    override suspend fun save(popup: Popup): Popup {
+        val existing = loadEntityById(popup.id)
+        return if (existing == null) {
+            entityTemplate.insert(PopupEntity.of(popup)).awaitSingle()
+            popup
+        } else {
+            entityTemplate.update(existing.update(popup)).awaitSingle()
+            popup
+        }
+    }
+
+    override suspend fun save(popups: List<Popup>): List<Popup> =
+        popups.map { save(it) }
+
+    override suspend fun deleteById(id: PopupId) {
+        loadEntityById(id)?.let { entityTemplate.delete(it).awaitSingle() }
+    }
+
+    private suspend fun loadEntityById(id: PopupId): PopupEntity? =
+        entityTemplate
+            .selectOne(query(where("id").`is`(id)), entityClass)
+            .awaitSingleOrNull()
+}

--- a/src/main/kotlin/com/wheretopop/infrastructure/popup/external/PopupExternalManager.kt
+++ b/src/main/kotlin/com/wheretopop/infrastructure/popup/external/PopupExternalManager.kt
@@ -1,0 +1,13 @@
+package com.wheretopop.infrastructure.popup.external
+
+import com.wheretopop.application.popup.PopupPopplyUseCase
+import org.springframework.stereotype.Component
+
+@Component
+class PopupExternalManager(
+    private val popupExternalStore: PopupExternalStore
+): PopupPopplyUseCase {
+    override suspend fun crawlPopplyAndSave() {
+        return popupExternalStore.crawlPopplyAndSave()
+    }
+}

--- a/src/main/kotlin/com/wheretopop/infrastructure/popup/external/PopupExternalManager.kt
+++ b/src/main/kotlin/com/wheretopop/infrastructure/popup/external/PopupExternalManager.kt
@@ -5,7 +5,8 @@ import org.springframework.stereotype.Component
 
 @Component
 class PopupExternalManager(
-    private val popupExternalStore: PopupExternalStore
+    private val popupExternalStore: PopupExternalStore,
+    private val popupExternalReader: PopupExternalReader
 ): PopupPopplyUseCase {
     override suspend fun crawlPopplyAndSave() {
         return popupExternalStore.crawlPopplyAndSave()

--- a/src/main/kotlin/com/wheretopop/infrastructure/popup/external/PopupExternalReader.kt
+++ b/src/main/kotlin/com/wheretopop/infrastructure/popup/external/PopupExternalReader.kt
@@ -1,0 +1,4 @@
+package com.wheretopop.infrastructure.popup.external
+
+interface PopupExternalReader {
+}

--- a/src/main/kotlin/com/wheretopop/infrastructure/popup/external/PopupExternalReaderImpl.kt
+++ b/src/main/kotlin/com/wheretopop/infrastructure/popup/external/PopupExternalReaderImpl.kt
@@ -1,0 +1,7 @@
+package com.wheretopop.infrastructure.popup.external
+
+import org.springframework.stereotype.Component
+
+@Component
+class PopupExternalReaderImpl: PopupExternalReader {
+}

--- a/src/main/kotlin/com/wheretopop/infrastructure/popup/external/PopupExternalStore.kt
+++ b/src/main/kotlin/com/wheretopop/infrastructure/popup/external/PopupExternalStore.kt
@@ -1,0 +1,5 @@
+package com.wheretopop.infrastructure.popup.external
+
+interface PopupExternalStore {
+    suspend fun crawlPopplyAndSave()
+}

--- a/src/main/kotlin/com/wheretopop/infrastructure/popup/external/PopupExternalStoreImpl.kt
+++ b/src/main/kotlin/com/wheretopop/infrastructure/popup/external/PopupExternalStoreImpl.kt
@@ -1,0 +1,14 @@
+package com.wheretopop.infrastructure.popup.external
+
+import com.wheretopop.infrastructure.popup.external.popply.PopplyProcessor
+import org.springframework.stereotype.Component
+
+@Component
+class PopupExternalStoreImpl(
+    private val popplyProcessor: PopplyProcessor
+): PopupExternalStore {
+
+    override suspend fun crawlPopplyAndSave() {
+        popplyProcessor.crawlAndSave()
+    }
+}

--- a/src/main/kotlin/com/wheretopop/infrastructure/popup/external/popply/PopplyDetailDto.kt
+++ b/src/main/kotlin/com/wheretopop/infrastructure/popup/external/popply/PopplyDetailDto.kt
@@ -2,14 +2,15 @@ package com.wheretopop.infrastructure.popup.external.popply
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
+import java.time.Instant
 
-// 최종 팝업 상세 정보를 담을 데이터 클래스
+// 팝업 상세 정보를 담을 데이터 클래스
 data class PopupDetail(
-    val title: String,
+    val name: String,
     val address: String,
-    val optionalAddress: String,
-    val startDate: String?,
-    val endDate: String?,
+    val optionalAddress: String?,
+    val startDate: Instant?,
+    val endDate: Instant?,
     val description: String,
     val url: String?,
     val latitude: Double?,

--- a/src/main/kotlin/com/wheretopop/infrastructure/popup/external/popply/PopplyDetailDto.kt
+++ b/src/main/kotlin/com/wheretopop/infrastructure/popup/external/popply/PopplyDetailDto.kt
@@ -1,0 +1,75 @@
+package com.wheretopop.infrastructure.popup.external.popply
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+
+// 최종 팝업 상세 정보를 담을 데이터 클래스
+data class PopupDetail(
+    val title: String,
+    val address: String,
+    val optionalAddress: String,
+    val startDate: String?,
+    val endDate: String?,
+    val description: String,
+    val url: String?,
+    val latitude: Double?,
+    val longitude: Double?,
+    val organizerName: String?,
+    val organizerUrl: String?,
+    val popplyId: Int
+)
+
+// JSON-LD 스키마를 위한 데이터 클래스
+// ignoreUnknown = true 설정으로 JSON 내 모든 필드를 매핑하지 않아도 됨
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class JsonLdData(
+    @JsonProperty("@context") val context: String? = null,
+    @JsonProperty("@type") val type: String? = null,
+    val name: String? = null,
+    val description: String? = null,
+    val url: String? = null,
+    val startDate: String? = null,
+    val endDate: String? = null,
+    val image: List<String>? = null,
+    val eventAttendanceMode: String? = null,
+    val location: List<LocationData>? = null,
+    val address: AddressData? = null,
+    val organizer: OrganizerData? = null,
+    val geo: GeoData? = null,
+    val openingHoursSpecification: List<List<OpeningHoursData>>? = null // 2중 배열 대응
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class LocationData(
+    @JsonProperty("@type") val type: String? = null,
+    val name: String? = null,
+    val address: AddressData? = null
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class AddressData(
+    @JsonProperty("@type") val type: String? = null,
+    val name: String? = null
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class OrganizerData(
+    @JsonProperty("@type") val type: String? = null,
+    val name: String? = null,
+    val url: String? = null
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class GeoData(
+    @JsonProperty("@type") val type: String? = null,
+    val latitude: Double? = null,
+    val longitude: Double? = null
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class OpeningHoursData(
+    @JsonProperty("@type") val type: String? = null,
+    val dayOfWeek: List<String>? = null,
+    val opens: String? = null,
+    val closes: String? = null
+)

--- a/src/main/kotlin/com/wheretopop/infrastructure/popup/external/popply/PopplyProcessor.kt
+++ b/src/main/kotlin/com/wheretopop/infrastructure/popup/external/popply/PopplyProcessor.kt
@@ -1,0 +1,8 @@
+package com.wheretopop.infrastructure.popup.external.popply
+
+/**
+ * 팝플리에서 정보를 크롤링하고, 이를 가공하여 Popup 도메인에 맞는 형태로 변환하는 책임
+ */
+interface PopplyProcessor {
+    suspend fun crawlAndSave()
+}

--- a/src/main/kotlin/com/wheretopop/infrastructure/popup/external/popply/PopupListCrawler.kt
+++ b/src/main/kotlin/com/wheretopop/infrastructure/popup/external/popply/PopupListCrawler.kt
@@ -1,0 +1,63 @@
+package com.wheretopop.infrastructure.popup.external.popply
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import mu.KotlinLogging
+import org.openqa.selenium.By
+import org.openqa.selenium.TimeoutException
+import org.openqa.selenium.WebDriver
+import org.openqa.selenium.WebElement
+import org.openqa.selenium.support.ui.ExpectedConditions
+import org.openqa.selenium.support.ui.WebDriverWait
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import java.time.Duration
+
+private val logger = KotlinLogging.logger {}
+
+@Component
+class PopupListCrawler(
+    private val driver: WebDriver,
+    @Value("\${scraping.target.url:https://popply.co.kr/popup}") private val targetUrl: String,
+    @Value("\${scraping.target.selector.firstPopupLink:div.popuplist-board > ul:nth-of-type(1) > li:nth-of-type(1) div.popup-info-wrap > a}") private val cssSelector: String,
+    @Value("\${scraping.wait.timeoutSeconds:15}") private val timeoutSeconds: Long
+) {
+
+    suspend fun fetchFirstPopupId(): Int? = withContext(Dispatchers.IO) {
+        try {
+            driver.get(targetUrl)
+
+            val wait = WebDriverWait(driver, Duration.ofSeconds(timeoutSeconds))
+            val firstListItemSelector = "div.popuplist-board > ul:nth-of-type(1) > li:nth-of-type(1)"
+            wait.until(ExpectedConditions.presenceOfElementLocated(By.cssSelector(firstListItemSelector)))
+
+            val linkElement: WebElement = driver.findElement(By.cssSelector(cssSelector))
+
+            val hrefAttribute = linkElement.getAttribute("href")
+
+            if (hrefAttribute == null) {
+                logger.warn("href 속성을 찾을 수 없습니다.")
+                return@withContext null
+            }
+            val idString = hrefAttribute.substringAfterLast('/', "")
+            val popupId = idString.toIntOrNull()
+
+            if (popupId == null) {
+                logger.error("href ('{}')에서 마지막 숫자 ID를 추출하거나 Int로 변환할 수 없습니다. 추출된 문자열: '{}'", hrefAttribute, idString)
+                return@withContext null
+            }
+
+            return@withContext popupId
+
+        } catch (e: TimeoutException) {
+            logger.error("페이지 로드 또는 요소 검색 시간 초과 ({}초): {}", timeoutSeconds, e.message)
+            return@withContext null
+        } catch (e: NoSuchElementException) {
+            logger.error("지정한 CSS 선택자({})로 요소를 찾을 수 없습니다: {}", cssSelector, e.message)
+            return@withContext null
+        } catch (e: Exception) {
+            logger.error("스크래핑 중 예상치 못한 오류 발생: {}", e.message, e)
+            return@withContext null
+        }
+    }
+}

--- a/src/main/kotlin/com/wheretopop/infrastructure/popup/external/popply/PopupPopplyDetailCrawler.kt
+++ b/src/main/kotlin/com/wheretopop/infrastructure/popup/external/popply/PopupPopplyDetailCrawler.kt
@@ -1,0 +1,114 @@
+package com.wheretopop.infrastructure.popup.external.popply
+
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
+import mu.KotlinLogging
+import org.jsoup.Jsoup
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.awaitBody
+import reactor.core.publisher.Mono
+import java.util.regex.Pattern
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * Popply Popup 상세 페이지 크롤링 담당 클래스
+ */
+@Component
+class PopupPopplyDetailCrawler(
+    @Qualifier("popupApiWebClient") private val webClient: WebClient,
+    private val objectMapper: ObjectMapper
+) {
+    private val addressRegex: Pattern = Pattern.compile("^(.*?(?:로|길|가)\\s*\\d+)(?:\\s+(.*))?\$")
+
+    /**
+     * 주어진 popupId에 해당하는 팝업 상세 정보를 크롤링합니다.
+     *
+     * @param popupId 크롤링할 팝업의 ID
+     * @return 크롤링된 PopupDetail 객체. 실패 시 null 반환.
+     */
+    suspend fun crawlDetail(popupId: Int): PopupDetail? {
+        val relativePath = "/$popupId"
+        logger.info { "Crawling popup detail for ID $popupId using relative path: $relativePath" }
+
+        return try {
+            val htmlResponse = webClient.get()
+                .uri { uriBuilder ->
+                    uriBuilder
+                        .path("/{id}") // 경로 변수 템플릿
+                        .build(popupId) // 템플릿에 실제 값 매핑
+                }
+                .header("User-Agent", "Mozilla/5.0")
+                .retrieve()
+                .onStatus({ status -> !status.is2xxSuccessful }) { response ->
+                    logger.error { "Page loading failed for ID $popupId. Status code: ${response.statusCode()}" }
+                    Mono.error(RuntimeException("Page loading failed with status code ${response.statusCode()}"))
+                }
+                .awaitBody<String>()
+
+            val document = Jsoup.parse(htmlResponse)
+            val jsonLdScriptElement = document.selectFirst("script[type=\"application/ld+json\"]")
+
+            if (jsonLdScriptElement == null) {
+                logger.warn { "[!] ID $popupId: JSON-LD script not found." }
+                return null
+            }
+
+            val jsonLdString = jsonLdScriptElement.data()
+            val jsonLdList: List<JsonLdData> = objectMapper.readValue(jsonLdString, object : TypeReference<List<JsonLdData>>() {})
+
+            val eventData = jsonLdList.find { it.type == "Event" }
+            val localBusinessData = jsonLdList.find { it.type == "LocalBusiness" }
+
+            if (eventData == null) {
+                logger.warn { "[!] ID $popupId: 'Event' type data not found in JSON-LD." }
+                return null
+            }
+
+            val title = eventData.name?.trim() ?: ""
+            val fullAddress = eventData.location?.firstOrNull()?.address?.name?.trim() ?: ""
+            val startDate = eventData.startDate
+            val endDate = eventData.endDate
+            val description = eventData.description?.trim() ?: ""
+
+            val matcher = addressRegex.matcher(fullAddress)
+            val (address, optionalAddress) = if (matcher.find()) {
+                val mainAddress = matcher.group(1)?.trim() ?: fullAddress
+                val optAddress = matcher.group(2)?.trim() ?: ""
+                mainAddress to optAddress
+            } else {
+                fullAddress to ""
+            }
+
+            val eventUrl = localBusinessData?.url
+            val latitude = localBusinessData?.geo?.latitude
+            val longitude = localBusinessData?.geo?.longitude
+            val organizerName = eventData.organizer?.name
+            val organizerUrl = eventData.organizer?.url
+
+            logger.info { "[+] ID $popupId: Event information collected successfully." }
+
+            PopupDetail(
+                title = title,
+                address = address,
+                optionalAddress = optionalAddress,
+                startDate = startDate,
+                endDate = endDate,
+                description = description,
+                url = eventUrl,
+                latitude = latitude,
+                longitude = longitude,
+                organizerName = organizerName,
+                organizerUrl = organizerUrl,
+                popplyId = popupId
+            )
+
+        } catch(e: Exception) {
+            logger.error(e) { "[!] ID $popupId: Failed to crawl or process data: ${e.message}" }
+            null
+        }
+    }
+
+}

--- a/src/main/kotlin/com/wheretopop/infrastructure/popup/external/popply/PopupPopplyEntity.kt
+++ b/src/main/kotlin/com/wheretopop/infrastructure/popup/external/popply/PopupPopplyEntity.kt
@@ -1,0 +1,116 @@
+package com.wheretopop.infrastructure.popup.external.popply
+
+import com.wheretopop.domain.popup.PopupId
+import com.wheretopop.shared.model.UniqueId
+import org.springframework.core.convert.converter.Converter
+import org.springframework.data.annotation.Id
+import org.springframework.data.convert.ReadingConverter
+import org.springframework.data.convert.WritingConverter
+import org.springframework.data.relational.core.mapping.Column
+import org.springframework.data.relational.core.mapping.Table
+import java.time.Instant
+
+class PopupPopplyId private constructor(
+    value: Long
+) : UniqueId(value) {
+    companion object {
+        @JvmStatic
+        fun create(): PopupPopplyId {
+            return PopupPopplyId(UniqueId.create().value)
+        }
+
+        @JvmStatic
+        fun of(value: Long): PopupPopplyId {
+            return PopupPopplyId(UniqueId.of(value).value)
+        }
+    }
+}
+
+@Table("popup_popply")
+data class PopupPopplyEntity(
+    @Id
+    @Column("id")
+    val id: PopupPopplyId = PopupPopplyId.create(),
+
+    @Column("popup_id")
+    val popupId: Long,
+
+    @Column("popup_name")
+    val popupName: String,
+
+    @Column("address")
+    val address: String,
+
+    @Column("optional_address")
+    val optionalAddress: String? = null,
+
+    @Column("start_date")
+    val startDate: Instant? = null,
+
+    @Column("end_date")
+    val endDate: Instant? = null,
+
+    @Column("description")
+    val description: String,
+
+    @Column("url")
+    val url: String? = null,
+
+    @Column("latitude")
+    val latitude: Double? = null,
+
+    @Column("longitude")
+    val longitude: Double? = null,
+
+    @Column("organizer_name")
+    val organizerName: String? = null,
+
+    @Column("organizer_url")
+    val organizerUrl: String? = null,
+
+    @Column("popply_id")
+    val popplyId: Int,
+
+    @Column("created_at")
+    val createdAt: Instant = Instant.now(),
+
+    @Column("updated_at")
+    val updatedAt: Instant = Instant.now(),
+
+    @Column("deleted_at")
+    val deletedAt: Instant? = null
+
+) {
+    companion object {
+        fun of(popupDetail: PopupDetail, popupId: Long): PopupPopplyEntity {
+            return PopupPopplyEntity(
+                id = PopupPopplyId.create(),
+                popupId = popupId,
+                popupName = popupDetail.name,
+                address = popupDetail.address,
+                optionalAddress = popupDetail.optionalAddress,
+                startDate = popupDetail.startDate,
+                endDate = popupDetail.endDate,
+                description = popupDetail.description,
+                url = popupDetail.url,
+                latitude = popupDetail.latitude,
+                longitude = popupDetail.longitude,
+                organizerName = popupDetail.organizerName,
+                organizerUrl = popupDetail.organizerUrl,
+                popplyId = popupDetail.popplyId,
+                createdAt = Instant.now(),
+                updatedAt = Instant.now()
+            )
+        }
+    }
+}
+
+@WritingConverter
+class PopupPopplyIdToLongConverter : Converter<PopupPopplyId, Long> {
+    override fun convert(source: PopupPopplyId) = source.toLong()
+}
+
+@ReadingConverter
+class LongToPopupPopplyIdConverter : Converter<Long, PopupPopplyId> {
+    override fun convert(source: Long) = PopupPopplyId.of(source)
+}

--- a/src/main/kotlin/com/wheretopop/infrastructure/popup/external/popply/PopupPopplyProcessor.kt
+++ b/src/main/kotlin/com/wheretopop/infrastructure/popup/external/popply/PopupPopplyProcessor.kt
@@ -1,0 +1,36 @@
+package com.wheretopop.infrastructure.popup.external.popply
+
+import mu.KotlinLogging
+import org.springframework.stereotype.Service
+import java.time.LocalDate
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * 팝플리 팝업스토어 데이터 서비스
+ * 크롤링과 데이터 저장의 전체 흐름을 관리합니다.
+ */
+@Service
+class PopupPopplyProcessor(
+    private val popupPopplyDetailCrawler: PopupPopplyDetailCrawler
+) : PopplyProcessor {
+
+    /**
+     * for test
+     */
+    override suspend fun crawlAndSave() {
+//        val popupDetailData = popupPopplyDetailCrawler.crawlDetail(15)
+//        logger.info { "Popply Detail: ${popupDetailData}"}
+    }
+
+    /**
+     * 기간에 맞춰 팝업 상세 정보들을 크롤링
+     */
+    suspend fun crawlPopupDetailsByPeriod(startDate: LocalDate, endDate: LocalDate) {}
+
+    /**
+     * 주어진 ID 범위에 해당하는 팝업 상세 정보들을 크롤링
+     * for test
+     */
+    suspend fun crawlPopupDetailsByIdRange(startId: Int, endId: Int) {}
+}

--- a/src/main/kotlin/com/wheretopop/infrastructure/popup/external/popply/PopupPopplyProcessor.kt
+++ b/src/main/kotlin/com/wheretopop/infrastructure/popup/external/popply/PopupPopplyProcessor.kt
@@ -1,5 +1,7 @@
 package com.wheretopop.infrastructure.popup.external.popply
 
+import com.wheretopop.domain.popup.Popup
+import com.wheretopop.infrastructure.popup.PopupRepository
 import mu.KotlinLogging
 import org.springframework.stereotype.Service
 import java.time.LocalDate
@@ -12,15 +14,54 @@ private val logger = KotlinLogging.logger {}
  */
 @Service
 class PopupPopplyProcessor(
-    private val popupPopplyDetailCrawler: PopupPopplyDetailCrawler
+    private val popupPopplyDetailCrawler: PopupPopplyDetailCrawler,
+    private val popupPopplyRepository: PopupPopplyRepository,
+    private val popupRepository: PopupRepository,
+    private val popupListCrawler: PopupListCrawler,
 ) : PopplyProcessor {
 
-    /**
-     * for test
-     */
     override suspend fun crawlAndSave() {
-//        val popupDetailData = popupPopplyDetailCrawler.crawlDetail(15)
-//        logger.info { "Popply Detail: ${popupDetailData}"}
+        val popupId = popupListCrawler.fetchFirstPopupId()
+        if (popupId == null) return
+        crawlDownPopupDetailsById(popupId)
+    }
+
+    /**
+     * 팝플리에서 하나의 팝업 정보를 crawl
+     * Popup 생성
+     * popup_id 넘겨줌
+     * 도메인 객체로 변환 (Popup)
+     * 도메인 객체 저장
+     */
+    suspend fun processAndSavePopupDetail(popplyId: Int): Boolean {
+        val existing = popupPopplyRepository.findByPopplyId(popplyId)
+        if (existing != null) return false
+//        logger.info("Popply ID {} 상세 정보 처리 시작...", popplyId)
+        val popupDetailData: PopupDetail = popupPopplyDetailCrawler.crawlDetail(popplyId)
+            ?: run {
+                logger.error("ID {} 에 해당하는 Popply 상세 정보를 찾을 수 없습니다.", popplyId)
+                return false
+            }
+
+        val newPopup = Popup.create(
+            name = popupDetailData.name,
+            address = popupDetailData.address,
+        )
+//        logger.info("새로운 Popup 객체 생성 완료: 이름={}", newPopup.name)
+
+        val savedPopup = popupRepository.save(newPopup)
+
+        val generatedPopupId = savedPopup.id
+//        logger.info("PopupEntity 저장 완료: ID={}", generatedPopupId.value)
+
+        val popupPopplyEntity = PopupPopplyEntity.of(
+            popupDetail = popupDetailData,
+            popupId = generatedPopupId.toLong(),
+        )
+
+        popupPopplyRepository.save(popupPopplyEntity)
+//        logger.info("PopupPopplyEntity 저장 완료.")
+        return true
     }
 
     /**
@@ -29,8 +70,33 @@ class PopupPopplyProcessor(
     suspend fun crawlPopupDetailsByPeriod(startDate: LocalDate, endDate: LocalDate) {}
 
     /**
-     * 주어진 ID 범위에 해당하는 팝업 상세 정보들을 크롤링
-     * for test
+     * 주어진 ID부터 역순으로 팝업 상세 정보들을 크롤링
+     * 이미 있는 Popup 이면, 종료!
      */
-    suspend fun crawlPopupDetailsByIdRange(startId: Int, endId: Int) {}
+    suspend fun crawlDownPopupDetailsById(endId: Int, startId:Int = 15) {
+        logger.info("ID 범위 {}부터 {}까지 (역순) 팝업 상세 정보 크롤링 시작...", startId, endId)
+        var successCount = 0
+        var stoppedEarly = false
+        var processedCount = 0
+
+        for (id in endId downTo startId) {
+            processedCount++
+            logger.debug("ID {} 처리 시도", id)
+
+            val success = processAndSavePopupDetail(id)
+
+            if (success) {
+                successCount++
+            } else {
+                logger.info("ID {} 처리 중 중단 조건 발견. 크롤링을 중단합니다.", id)
+                stoppedEarly = true
+                break
+            }
+        }
+
+        logger.info(
+            "Popups Crawling Completed: Attempts {}, Success {}, {}",
+            processedCount, successCount, if (stoppedEarly) "Stopped" else "Normally Ended"
+        )
+    }
 }

--- a/src/main/kotlin/com/wheretopop/infrastructure/popup/external/popply/PopupPopplyRepository.kt
+++ b/src/main/kotlin/com/wheretopop/infrastructure/popup/external/popply/PopupPopplyRepository.kt
@@ -1,0 +1,10 @@
+package com.wheretopop.infrastructure.popup.external.popply
+
+import com.wheretopop.domain.popup.PopupId
+
+interface PopupPopplyRepository {
+    suspend fun save(entity: PopupPopplyEntity): PopupPopplyEntity
+    suspend fun save(entities: List<PopupPopplyEntity>): List<PopupPopplyEntity>
+    suspend fun findByPopplyId(popplyId: Int): PopupPopplyEntity?
+    suspend fun findByPopupId(popupId: PopupId): PopupPopplyEntity?
+}

--- a/src/main/kotlin/com/wheretopop/infrastructure/popup/external/popply/R2dbcPopupPopplyRepository.kt
+++ b/src/main/kotlin/com/wheretopop/infrastructure/popup/external/popply/R2dbcPopupPopplyRepository.kt
@@ -1,0 +1,43 @@
+package com.wheretopop.infrastructure.popup.external.popply
+
+import com.wheretopop.domain.popup.PopupId
+import kotlinx.coroutines.reactor.awaitSingle
+import kotlinx.coroutines.reactor.awaitSingleOrNull
+import org.springframework.data.r2dbc.core.R2dbcEntityTemplate
+import org.springframework.data.relational.core.query.Criteria.where
+import org.springframework.data.relational.core.query.Query.query
+
+internal class R2dbcPopupPopplyRepository (
+    private val entityTemplate: R2dbcEntityTemplate
+) : PopupPopplyRepository {
+
+    private val entityClass = PopupPopplyEntity::class.java
+
+    override suspend fun save(entity: PopupPopplyEntity): PopupPopplyEntity {
+        val existing = loadEntityById(entity.id)
+        return if (existing == null) {
+            entityTemplate.insert(entity).awaitSingle()
+        } else {
+            entityTemplate.update(entity).awaitSingle()
+        }
+    }
+
+    override suspend fun save(entities: List<PopupPopplyEntity>): List<PopupPopplyEntity> =
+        entities.map { save(it) }
+
+    override suspend fun findByPopupId(popupId: PopupId): PopupPopplyEntity? =
+        entityTemplate
+            .selectOne(query(where("popup_id").`is`(popupId)), entityClass)
+            .awaitSingleOrNull()
+
+    override suspend fun findByPopplyId(popplyId: Int): PopupPopplyEntity? =
+        entityTemplate
+            .selectOne(query(where("popply_id").`is`(popplyId)), entityClass)
+            .awaitSingleOrNull()
+
+    private suspend fun loadEntityById(id: PopupPopplyId): PopupPopplyEntity? =
+        entityTemplate
+            .selectOne(query(where("id").`is`(id)), entityClass)
+            .awaitSingleOrNull()
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,6 +22,9 @@ openapi:
   seoul:
     key: ${SEOUL_OPEN_DATA_API_KEY:your_key}
 
+crawler:
+  popply:
+
 server:
   port: ${APP_PORT:8080}
   forward-headers-strategy: native

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,8 +22,18 @@ openapi:
   seoul:
     key: ${SEOUL_OPEN_DATA_API_KEY:your_key}
 
-crawler:
-  popply:
+selenium:
+  chrome:
+    headless: true
+    arguments: --disable-gpu
+scraping:
+  target:
+    url: https://popply.co.kr/popup
+    selector:
+      firstPopupLink: div.popuplist-board > ul:nth-of-type(1) > li:nth-of-type(1) div.popup-info-wrap > a
+  wait:
+    timeoutSeconds: 15
+
 
 server:
   port: ${APP_PORT:8080}

--- a/src/main/resources/db/changelog/init.sql
+++ b/src/main/resources/db/changelog/init.sql
@@ -53,3 +53,47 @@ CREATE TABLE IF NOT EXISTS area_populations (
     INDEX idx_area_population_update_time (population_update_time),
     INDEX idx_area_population_deleted_at (deleted_at)
     );
+
+-- popups 테이블 생성
+CREATE TABLE IF NOT EXISTS popups (
+    id BIGINT PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    address VARCHAR(500) NOT NULL,
+    created_at TIMESTAMP(6) NOT NULL,
+    deleted_at TIMESTAMP(6) DEFAULT NULL,
+
+    -- 검색 성능 향상을 위한 인덱스
+    INDEX idx_popups_name (name),
+    INDEX idx_popups_deleted_at (deleted_at)
+);
+
+-- popup_popply 테이블 생성
+CREATE TABLE IF NOT EXISTS popup_popply (
+    id BIGINT PRIMARY KEY,
+    popup_id BIGINT NOT NULL,
+    popup_name VARCHAR(255) NOT NULL,
+    address VARCHAR(500) NOT NULL,
+    optional_address VARCHAR(500) DEFAULT NULL,
+    start_date TIMESTAMP(6) DEFAULT NULL,
+    end_date TIMESTAMP(6) DEFAULT NULL,
+    description TEXT NOT NULL,
+    url VARCHAR(2048) DEFAULT NULL,
+    latitude DOUBLE PRECISION DEFAULT NULL,
+    longitude DOUBLE PRECISION DEFAULT NULL,
+    organizer_name VARCHAR(255) DEFAULT NULL,
+    organizer_url VARCHAR(2048) DEFAULT NULL,
+    popply_id INT NOT NULL,
+    created_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    deleted_at TIMESTAMP(6) DEFAULT NULL,
+
+    CONSTRAINT fk_popup_popply_popup
+        FOREIGN KEY (popup_id)
+        REFERENCES popups(id)
+        ON DELETE CASCADE,
+
+    INDEX idx_popup_popply_popup_id (popup_id),
+    INDEX idx_popup_popply_dates (start_date, end_date),
+    INDEX idx_popup_popply_popply_id (popply_id),
+    INDEX idx_popup_popply_deleted_at (deleted_at)
+);


### PR DESCRIPTION
## 🚀 작업 배경

-   Popply 웹사이트에서 최신 팝업 정보를 주기적으로 가져와 서비스 데이터베이스에 동기화 필요
-   이를 위해 팝업 목록에서 최신 팝업 ID를 확인하고, 해당 ID부터 시작하여 상세 정보를 크롤링하고 저장하는 기능을 구현했습니다.

## 📝 작업 내용

**1. 팝업 목록 최신 ID 추출 (`PopupListCrawler`)**

-   Selenium 라이브러리를 사용하여 팝업 목록 페이지([https://popply.co.kr/popup](https://popply.co.kr/popup))에 접속합니다.
-   가장 위에 있는 (최신) 팝업 게시물의 고유 ID를 추출합니다.
-   네트워크 I/O 및 페이지 로딩/파싱으로 인한 블로킹을 방지하기 위해 `withContext(Dispatchers.IO)`를 사용하여 코루틴 컨텍스트에서 실행하도록 했습니다.

**2. 팝업 상세 정보 크롤링 및 저장 (`DetailCrawler`)**

-   주어진 팝업 ID를 사용하여 Popply의 상세 페이지 정보를 크롤링하는 `DetailCrawler`를 구현했습니다.
-   크롤링한 상세 정보를 바탕으로 `Popup` 을 생성합니다.
-   크롤링 출처 및 고유 ID를 관리하기 위해 `PopplyEntity`를 생성하고, `Popup`의 ID를 FK로 참조하도록 설정했습니다.
-   생성된 `PopupEntity` 및 `PopplyEntity`를 데이터베이스에 저장합니다.

**3. 크롤링 실행 로직 구현(`PopupPopplyProcessor`)**

-   `PopupListCrawler`를 통해 얻은 최신 팝업 ID부터 시작하여 1씩 감소시키면서 `DetailCrawler`를 순차적으로 실행합니다.
-   `DetailCrawler` 실행 전, 해당 팝업 ID가 이미 데이터베이스에 존재하는지 확인합니다.
-   이미 존재하는 팝업 ID를 만나면, 그 이전의 팝업들은 이미 처리된 것으로 간주하고 크롤링 작업을 중단하여 불필요한 작업을 방지합니다.

**4. WebDriver 설정 및 생명주기 관리 개선 (`WebDriverConfig`)**
-   `application.yml`에서 headless 모드, Chrome 실행 인자 등의 설정을 주입받도록 구성했습니다.
-   `ChromeOptions`를 별도의 Bean으로 정의하여 WebDriver 설정을 명확히 분리했습니다.
-   `WebDriver` Bean 정의 시 `destroyMethod = "quit"` 속성을 설정하여, 스프링 컨테이너 종료 시 자동으로 `driver.quit()`가 호출되어 브라우저 프로세스 및 관련 리소스가 안전하게 정리되도록 했습니다.

## ✔️ 참고 사항

-   작명이나 코드 구조가 미흡한 부분이 있을 수 있습니다. 피드백 환영합니다!

## ⏳ 향후 작업 (TODO)

-   [ ] 크롤링된 `Popup` 정보와 `Building` (건물/장소) 정보 연동
-   [ ] `Popup` 정보 더 디테일하게?
-   [ ] 저장된 `Popup` 데이터를 효과적으로 검색하기 위한 조건(Criteria) 정의 및 구현