### PR TITLE
feat: ai client 추가 및 mcp 클라이언트 연동

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,8 @@ DB_HOST=localhost
 ES_HOST=localhost
 ES_PORT=9200
 ES_JAVA_OPTS="-Xms512m -Xmx512m"
+# openai API 설정 (gemini 모델 사용해도, openai specification을 따르므로 사용 가능)
+OPENAI_API_KEY=your_api_key_here
 # 서울 열린 데이터 광장 설정
 SEOUL_OPEN_DATA_API_KEY=your_api_key_here
 # 대한민국 공공 데이터 포털 설정

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ### 필수 사항
 
-- JDK 21
+- JDK 17
 - Docker & Docker Compose
 
 ### 시작하기

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,9 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-	id("org.springframework.boot") version "3.1.2"
+	id("org.springframework.boot") version "3.4.5"
 	id("io.spring.dependency-management") version "1.1.0"
-	id("org.asciidoctor.jvm.convert") version "3.3.2"
-	id("org.flywaydb.flyway") version "9.22.3"
+	id("org.asciidoctor.jvm.convert") version "4.0.2"
 	kotlin("jvm") version "1.9.23"
 	kotlin("plugin.spring") version "1.9.23"
 	kotlin("plugin.serialization") version "1.9.23"
@@ -12,11 +11,25 @@ plugins {
 
 group = "com.example"
 version = "0.0.1-SNAPSHOT"
-java.sourceCompatibility = JavaVersion.VERSION_17
+java.sourceCompatibility = JavaVersion.VERSION_21
 
 
 repositories {
+//	mavenLocal()
 	mavenCentral()
+	maven { url = uri("https://repo.spring.io/milestone") }
+	maven { url = uri("https://repo.spring.io/snapshot") }
+	maven {
+		url = uri("https://repo.spring.io/milestone")
+		mavenContent {
+			releasesOnly()
+		}
+	}
+	maven {
+		name = "Central Portal Snapshots"
+		url = uri("https://central.sonatype.com/repository/maven-snapshots/")
+	}
+
 }
 
 configurations {
@@ -28,6 +41,14 @@ configurations {
 
 
 dependencies {
+	// Spring AI
+//	implementation(platform("org.springframework.ai:spring-ai-bom:1.0.0-SNAPSHOT"))
+	implementation(platform("org.springframework.ai:spring-ai-bom:1.0.0-M8"))
+	implementation("org.springframework.ai:spring-ai-openai")
+	implementation("org.springframework.ai:spring-ai-starter-model-openai")
+	implementation("org.springframework.ai:spring-ai-starter-mcp-client")
+	implementation("org.springframework.ai:spring-ai-starter-mcp-server")
+
 	// Spring WebFlux + R2DBC
 	implementation("org.springframework.boot:spring-boot-starter-webflux")
 	implementation("org.springframework.boot:spring-boot-starter-data-r2dbc")
@@ -44,6 +65,9 @@ dependencies {
 	implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
 	implementation("io.github.microutils:kotlin-logging:3.0.5")
 
+
+
+	
 	// Bean Validation
 	implementation("org.springframework.boot:spring-boot-starter-validation")
 
@@ -65,7 +89,7 @@ dependencies {
 	// for crawling
 	implementation("org.jsoup:jsoup:1.19.1")
 	implementation("org.seleniumhq.selenium:selenium-java:4.31.0")
-	implementation("io.github.bonigarcia:webdrivermanager:5.8.0")
+//	implementation("io.github.bonigarcia:webdrivermanager:5.8.0")
 	implementation("org.apache.httpcomponents.client5:httpclient5:5.3.1")
 
 	// REST Docs
@@ -88,12 +112,12 @@ dependencies {
 
 
 kotlin {
-	jvmToolchain(17)
+	jvmToolchain(21)
 }
 
 tasks.withType<KotlinCompile> {
 	kotlinOptions {
-		jvmTarget = "17"
+		jvmTarget = "21"
 	}
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,7 +47,6 @@ dependencies {
 	implementation("org.springframework.ai:spring-ai-openai")
 	implementation("org.springframework.ai:spring-ai-starter-model-openai")
 	implementation("org.springframework.ai:spring-ai-starter-mcp-client")
-	implementation("org.springframework.ai:spring-ai-starter-mcp-server")
 
 	// Spring WebFlux + R2DBC
 	implementation("org.springframework.boot:spring-boot-starter-webflux")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,26 +61,25 @@ services:
       elasticsearch:
         condition: service_healthy
 
-  dbgate:
-    image: dbgate/dbgate:latest
-    container_name: wheretopop-dbgate
-    restart: always
-    environment:
-      CONNECTIONS: mariadb
-      LABEL_mariadb: MariaDB
-      SERVER_mariadb: mariadb
-      USER_mariadb: ${MYSQL_USER}
-      PASSWORD_mariadb: ${MYSQL_PASSWORD}
-      PORT_mariadb: ${DB_PORT}
-      DATABASE_mariadb: ${MYSQL_DATABASE}
-      ENGINE_mariadb: mysql@dbgate-plugin-mysql
-    ports:
-      - "8082:3000"
-    volumes:
-      - dbgate_data:/root/.dbgate
-    depends_on:
-      mariadb:
-        condition: service_healthy
+#  ollama:
+#    image: ollama/ollama:latest
+#    container_name: wheretopop-ollama
+#    restart: always
+#    ports:
+#      - "11434:11434"
+#    volumes:
+#      - ollama_data:/root/.ollama
+#    command: serve
+#    environment:
+#      - OLLAMA_MODELS=/root/.ollama/models
+#      - OLLAMA_HOST=0.0.0.0:11434
+#    healthcheck:
+#      test: ["CMD", "curl", "-s", "-f", "http://localhost:11434"]
+#      interval: 10s
+#      timeout: 5s
+#      retries: 10
+
+
 
   api:
     build:
@@ -97,6 +96,8 @@ services:
         condition: service_healthy
       elasticsearch:
         condition: service_healthy
+      ollama:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
       interval: 10s
@@ -110,3 +111,7 @@ volumes:
     driver: local
   dbgate_data:
     driver: local
+  ollama_data:
+    driver: local
+
+

--- a/src/main/kotlin/com/wheretopop/WhereToPopApplication.kt
+++ b/src/main/kotlin/com/wheretopop/WhereToPopApplication.kt
@@ -1,8 +1,12 @@
 package com.wheretopop
 
+import com.wheretopop.interfaces.mcp.McpToolRegistry
+import org.springframework.ai.tool.ToolCallbackProvider
+import org.springframework.ai.tool.method.MethodToolCallbackProvider
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
+import org.springframework.context.annotation.Bean
 import org.springframework.scheduling.annotation.EnableScheduling
 
 @SpringBootApplication
@@ -11,5 +15,11 @@ import org.springframework.scheduling.annotation.EnableScheduling
 class WhereToPopApplication
 
 fun main(args: Array<String>) {
+
 	runApplication<WhereToPopApplication>(*args)
+
+	@Bean
+	fun tools(mcpToolRegistry: McpToolRegistry?): ToolCallbackProvider {
+		return MethodToolCallbackProvider.builder().toolObjects(mcpToolRegistry).build()
+	}
 }

--- a/src/main/kotlin/com/wheretopop/application/chat/ChatContextUseCases.kt
+++ b/src/main/kotlin/com/wheretopop/application/chat/ChatContextUseCases.kt
@@ -1,0 +1,10 @@
+package com.wheretopop.application.chat
+
+import org.springframework.ai.chat.model.ChatResponse
+import reactor.core.publisher.Flux
+
+interface McpAiUseCase {
+    fun predictToolCall(query: String): Flux<ChatResponse>
+    fun inferDatabaseQueryCondition(naturalQuery: String): Flux<ChatResponse>
+    fun describeDatabaseSchema(naturalRequest: String): Flux<ChatResponse>
+}

--- a/src/main/kotlin/com/wheretopop/application/chat/ChatFacade.kt
+++ b/src/main/kotlin/com/wheretopop/application/chat/ChatFacade.kt
@@ -1,5 +1,10 @@
 package com.wheretopop.application.chat
 
+import com.wheretopop.infrastructure.chat.ai.AiChatClient
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.flatMapConcat
+import org.springframework.ai.chat.model.Generation
 import org.springframework.http.codec.ServerSentEvent
 import org.springframework.stereotype.Service
 import reactor.core.publisher.Flux
@@ -8,6 +13,7 @@ import reactor.core.publisher.Mono
 @Service
 class ChatFacade(
 //    private val chatService: ChatService
+    private val aiChatClient: AiChatClient
 ) {
 
     fun sendUserMessage(chatId: Long, userMessage: String): Mono<Void> {
@@ -19,4 +25,17 @@ class ChatFacade(
         TODO()
 //        return chatService.streamAssistantMessages(chatId)
     }
+
+
+    suspend fun chat(userMessage: String): String =
+        // DSL 블록으로 call 호출
+        aiChatClient.call(userMessage)
+
+    suspend fun streamGenerations(userMessage: String): Flow<Generation> =
+        // DSL 블록으로 stream 호출
+        aiChatClient.stream(userMessage).flatMapConcat {
+            it.results.asFlow()
+        }
+
+
 }

--- a/src/main/kotlin/com/wheretopop/config/ChatClientConfig.kt
+++ b/src/main/kotlin/com/wheretopop/config/ChatClientConfig.kt
@@ -1,0 +1,36 @@
+package com.wheretopop.config
+
+import com.wheretopop.interfaces.mcp.McpToolRegistry
+import org.slf4j.LoggerFactory
+import org.springframework.ai.chat.client.ChatClient
+import org.springframework.ai.chat.model.ChatModel
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+
+@Configuration
+class ChatClientConfig(
+    private val chatModel: ChatModel,
+    private val mcpToolRegistry: McpToolRegistry,
+//    private val toolCallbackProvider: ToolCallbackProvider,
+){
+
+    private val logger = LoggerFactory.getLogger(ChatClientConfig::class.java)
+
+
+
+    @Bean
+    fun chatClient(): ChatClient {
+//        val defaultCallbacks = toolCallbackProvider.toolCallbacks
+//        val selfHostedCallbacks = MethodToolCallbackProvider.builder()
+//            .toolObjects(mcpToolRegistry)
+//            .build()
+//            .toolCallbacks
+//        val tool = McpToolUtils.toAsyncToolSpecifications(*defaultCallbacks, *selfHostedCallbacks)
+
+
+        return ChatClient.builder(chatModel)
+            .defaultTools(mcpToolRegistry)
+            .build()
+    }
+}

--- a/src/main/kotlin/com/wheretopop/config/ChatClientConfig.kt
+++ b/src/main/kotlin/com/wheretopop/config/ChatClientConfig.kt
@@ -21,7 +21,7 @@ class ChatClientConfig(
 
     @Bean
     fun chatClient(): ChatClient {
-//        val defaultCallbacks = toolCallbackProvider.toolCallbacks
+ //        val defaultCallbacks = toolCallbackProvider.toolCallbacks
 //        val selfHostedCallbacks = MethodToolCallbackProvider.builder()
 //            .toolObjects(mcpToolRegistry)
 //            .build()

--- a/src/main/kotlin/com/wheretopop/config/R2dbcConfig.kt
+++ b/src/main/kotlin/com/wheretopop/config/R2dbcConfig.kt
@@ -8,16 +8,28 @@ import com.wheretopop.infrastructure.area.external.opendata.population.LongToAre
 import com.wheretopop.infrastructure.area.external.opendata.population.R2dbcAreaPopulationRepository
 import com.wheretopop.infrastructure.building.BuildingIdToLongConverter
 import com.wheretopop.infrastructure.building.LongToBuildingIdConverter
+import com.wheretopop.infrastructure.building.R2dbcBuildingRepository
 import com.wheretopop.infrastructure.building.register.BuildingRegisterIdToLongConverter
 import com.wheretopop.infrastructure.building.register.LongToBuildingRegisterIdConverter
+import com.wheretopop.infrastructure.building.register.R2dbcBuildingRegisterRepository
+import com.wheretopop.infrastructure.chat.ChatIdToLongConverter
+import com.wheretopop.infrastructure.chat.LongToChatIdConverter
+import com.wheretopop.infrastructure.chat.message.ChatMessageIdToLongConverter
+import com.wheretopop.infrastructure.chat.message.LongToChatMessageIdConverter
 import com.wheretopop.infrastructure.popup.LongToPopupIdConverter
 import com.wheretopop.infrastructure.popup.PopupIdToLongConverter
+import com.wheretopop.infrastructure.popup.R2dbcPopupRepository
 import com.wheretopop.infrastructure.popup.external.popply.LongToPopupPopplyIdConverter
 import com.wheretopop.infrastructure.popup.external.popply.PopupPopplyIdToLongConverter
-import com.wheretopop.infrastructure.popup.R2dbcPopupRepository
 import com.wheretopop.infrastructure.popup.external.popply.R2dbcPopupPopplyRepository
-import com.wheretopop.infrastructure.building.R2dbcBuildingRepository
-import com.wheretopop.infrastructure.building.register.R2dbcBuildingRegisterRepository
+import com.wheretopop.infrastructure.project.LongToProjectIdConverter
+import com.wheretopop.infrastructure.project.ProjectIdToLongConverter
+import com.wheretopop.infrastructure.user.LongToUserIdConverter
+import com.wheretopop.infrastructure.user.UserIdToLongConverter
+import com.wheretopop.infrastructure.user.auth.AuthUserIdToLongConverter
+import com.wheretopop.infrastructure.user.auth.LongToAuthUserIdConverter
+import com.wheretopop.infrastructure.user.auth.LongToRefreshTokenIdConverter
+import com.wheretopop.infrastructure.user.auth.RefreshTokenIdToLongConverter
 import io.r2dbc.spi.ConnectionFactory
 import org.mariadb.r2dbc.MariadbConnectionConfiguration
 import org.mariadb.r2dbc.MariadbConnectionFactory
@@ -76,7 +88,13 @@ class R2dbcConfig : AbstractR2dbcConfiguration() {
         PopupIdToLongConverter(), LongToPopupIdConverter(),
         PopupPopplyIdToLongConverter(), LongToPopupPopplyIdConverter(),
         BuildingIdToLongConverter(), LongToBuildingIdConverter(),
-        BuildingRegisterIdToLongConverter(), LongToBuildingRegisterIdConverter()
+        BuildingRegisterIdToLongConverter(), LongToBuildingRegisterIdConverter(),
+        ChatIdToLongConverter(), LongToChatIdConverter(),
+        ChatMessageIdToLongConverter(), LongToChatMessageIdConverter(),
+        UserIdToLongConverter(), LongToUserIdConverter(),
+        AuthUserIdToLongConverter(), LongToAuthUserIdConverter(),
+        RefreshTokenIdToLongConverter(), LongToRefreshTokenIdConverter(),
+        ProjectIdToLongConverter(), LongToProjectIdConverter()
     )
 
 

--- a/src/main/kotlin/com/wheretopop/config/WebClientConfig.kt
+++ b/src/main/kotlin/com/wheretopop/config/WebClientConfig.kt
@@ -3,6 +3,8 @@
     import org.springframework.context.annotation.Bean
     import org.springframework.context.annotation.Configuration
     import org.springframework.web.reactive.function.client.WebClient
+    import org.springframework.web.util.DefaultUriBuilderFactory
+    import org.springframework.web.util.DefaultUriBuilderFactory.EncodingMode
 
     @Configuration
     class WebClientConfig {

--- a/src/main/kotlin/com/wheretopop/config/WebClientConfig.kt
+++ b/src/main/kotlin/com/wheretopop/config/WebClientConfig.kt
@@ -3,9 +3,6 @@
     import org.springframework.context.annotation.Bean
     import org.springframework.context.annotation.Configuration
     import org.springframework.web.reactive.function.client.WebClient
-    import org.springframework.web.util.DefaultUriBuilderFactory
-    import org.springframework.web.util.DefaultUriBuilderFactory.EncodingMode
-
 
     @Configuration
     class WebClientConfig {

--- a/src/main/kotlin/com/wheretopop/config/WebDriverConfig.kt
+++ b/src/main/kotlin/com/wheretopop/config/WebDriverConfig.kt
@@ -1,6 +1,5 @@
 package com.wheretopop.config
 
-import io.github.bonigarcia.wdm.WebDriverManager
 import org.openqa.selenium.WebDriver
 import org.openqa.selenium.chrome.ChromeDriver
 import org.openqa.selenium.chrome.ChromeOptions
@@ -39,13 +38,19 @@ class WebDriverConfig {
      * - Spring이 Bean을 소멸시킬 때(애플리케이션 종료 등) 자동으로 driver.quit()를 호출하도록 destroyMethod 설정합니다.
      * - 기본적으로 Singleton 스코프로 생성
      */
-    @Bean(destroyMethod = "quit") // Bean 소멸 시 quit 메소드 자동 호출
+//    @Bean(destroyMethod = "quit") // Bean 소멸 시 quit 메소드 자동 호출
+//    fun chromeDriver(chromeOptions: ChromeOptions): WebDriver {
+//        WebDriverManager.chromedriver().setup()
+//        val driver = ChromeDriver(chromeOptions)
+//        return driver
+//        // 참고: 만약 여러 요청이 동시에 이 드라이버를 사용한다면 스레드 안전성 문제가 발생할 수 있음
+//        // 동시성 문제가 우려된다면 WebDriver Pooling 등을 고려해야 함
+//        // 기본적인 스케줄러 기반의 단일 스크래핑 작업 등에는 Singleton 스코프가 효율적
+//    }
+
+    @Bean(destroyMethod = "quit")
     fun chromeDriver(chromeOptions: ChromeOptions): WebDriver {
-        WebDriverManager.chromedriver().setup()
-        val driver = ChromeDriver(chromeOptions)
-        return driver
-        // 참고: 만약 여러 요청이 동시에 이 드라이버를 사용한다면 스레드 안전성 문제가 발생할 수 있음
-        // 동시성 문제가 우려된다면 WebDriver Pooling 등을 고려해야 함
-        // 기본적인 스케줄러 기반의 단일 스크래핑 작업 등에는 Singleton 스코프가 효율적
+        // WebDriverManager.chromedriver().setup() 호출 제거
+        return ChromeDriver(chromeOptions)
     }
 }

--- a/src/main/kotlin/com/wheretopop/domain/chat/Chat.kt
+++ b/src/main/kotlin/com/wheretopop/domain/chat/Chat.kt
@@ -1,18 +1,27 @@
 package com.wheretopop.domain.chat
 
+import com.wheretopop.infrastructure.project.ProjectId
+import com.wheretopop.infrastructure.user.UserId
 import java.time.Instant
 
 class Chat private constructor(
-    id: ChatId,
-    // userId: UserId
-    messages: List<ChatMessage>,
-    createdAt: Instant,
-    updatedAt: Instant,
-    deletedAt: Instant? = null
+    val id: ChatId,
+    val userId: UserId,
+    val projectId: ProjectId,
+    val isActive: Boolean,
+    val title: String,
+    val messages: List<ChatMessage>,
+    val createdAt: Instant,
+    val updatedAt: Instant,
+    val deletedAt: Instant? = null
 ){
     companion object {
         fun create(
             id: ChatId,
+            userId: UserId,
+            projectId: ProjectId,
+            isActive: Boolean,
+            title: String,
             messages: List<ChatMessage>,
             createdAt: Instant,
             updatedAt: Instant,
@@ -20,6 +29,10 @@ class Chat private constructor(
         ): Chat {
             return Chat(
                 id,
+                userId,
+                projectId,
+                isActive,
+                title,
                 messages,
                 createdAt,
                 updatedAt,

--- a/src/main/kotlin/com/wheretopop/domain/chat/Chat.kt
+++ b/src/main/kotlin/com/wheretopop/domain/chat/Chat.kt
@@ -1,0 +1,30 @@
+package com.wheretopop.domain.chat
+
+import java.time.Instant
+
+class Chat private constructor(
+    id: ChatId,
+    // userId: UserId
+    messages: List<ChatMessage>,
+    createdAt: Instant,
+    updatedAt: Instant,
+    deletedAt: Instant? = null
+){
+    companion object {
+        fun create(
+            id: ChatId,
+            messages: List<ChatMessage>,
+            createdAt: Instant,
+            updatedAt: Instant,
+            deletedAt: Instant? = null
+        ): Chat {
+            return Chat(
+                id,
+                messages,
+                createdAt,
+                updatedAt,
+                deletedAt
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/wheretopop/domain/chat/ChatId.kt
+++ b/src/main/kotlin/com/wheretopop/domain/chat/ChatId.kt
@@ -1,0 +1,19 @@
+package com.wheretopop.domain.chat
+
+import com.wheretopop.shared.model.UniqueId
+
+class ChatId private constructor(
+    value: Long
+) : UniqueId(value) {
+    companion object {
+        @JvmStatic
+        fun create(): ChatId {
+            return ChatId(UniqueId.create().value)
+        }
+
+        @JvmStatic
+        fun of(value: Long): ChatId {
+            return ChatId(UniqueId.of(value).value)
+        }
+    }
+}

--- a/src/main/kotlin/com/wheretopop/domain/chat/ChatMessage.kt
+++ b/src/main/kotlin/com/wheretopop/domain/chat/ChatMessage.kt
@@ -1,29 +1,39 @@
 package com.wheretopop.domain.chat
 
-import com.wheretopop.shared.enums.ChatMessageAuthor
+import com.wheretopop.shared.enums.ChatMessageFinishReason
+import com.wheretopop.shared.enums.ChatMessageRole
 import java.time.Instant
 
-class ChatMessage private  constructor(
-    chatMessageId: ChatMessageId,
-    author: ChatMessageAuthor,
-    content: String,
-    createdAt: Instant,
-    updatedAt: Instant,
-    deletedAt: Instant? = null
+class ChatMessage private constructor(
+    val id: ChatMessageId,
+    val chatId: ChatId,
+    val role: ChatMessageRole,
+    val content: String,
+    val finishReason: ChatMessageFinishReason,
+    val latencyMs: Long,
+    val createdAt: Instant,
+    val updatedAt: Instant,
+    val deletedAt: Instant? = null
 ){
     companion object{
         fun create(
-            chatMessageId: ChatMessageId,
-            author: ChatMessageAuthor,
+            id: ChatMessageId,
+            chatId: ChatId,
+            role: ChatMessageRole,
             content: String,
+            finishReason: ChatMessageFinishReason,
+            latencyMs: Long,
             createdAt: Instant,
             updatedAt: Instant,
             deletedAt: Instant? = null
         ): ChatMessage {
             return ChatMessage(
-                chatMessageId,
-                author,
+                id,
+                chatId,
+                role,
                 content,
+                finishReason,
+                latencyMs,
                 createdAt,
                 updatedAt,
                 deletedAt

--- a/src/main/kotlin/com/wheretopop/domain/chat/ChatMessage.kt
+++ b/src/main/kotlin/com/wheretopop/domain/chat/ChatMessage.kt
@@ -1,0 +1,33 @@
+package com.wheretopop.domain.chat
+
+import com.wheretopop.shared.enums.ChatMessageAuthor
+import java.time.Instant
+
+class ChatMessage private  constructor(
+    chatMessageId: ChatMessageId,
+    author: ChatMessageAuthor,
+    content: String,
+    createdAt: Instant,
+    updatedAt: Instant,
+    deletedAt: Instant? = null
+){
+    companion object{
+        fun create(
+            chatMessageId: ChatMessageId,
+            author: ChatMessageAuthor,
+            content: String,
+            createdAt: Instant,
+            updatedAt: Instant,
+            deletedAt: Instant? = null
+        ): ChatMessage {
+            return ChatMessage(
+                chatMessageId,
+                author,
+                content,
+                createdAt,
+                updatedAt,
+                deletedAt
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/wheretopop/domain/chat/ChatMessageId.kt
+++ b/src/main/kotlin/com/wheretopop/domain/chat/ChatMessageId.kt
@@ -1,0 +1,19 @@
+package com.wheretopop.domain.chat
+
+import com.wheretopop.shared.model.UniqueId
+
+class ChatMessageId private constructor(
+    value: Long
+) : UniqueId(value) {
+    companion object {
+        @JvmStatic
+        fun create(): ChatMessageId {
+            return ChatMessageId(UniqueId.create().value)
+        }
+
+        @JvmStatic
+        fun of(value: Long): ChatMessageId {
+            return ChatMessageId(UniqueId.of(value).value)
+        }
+    }
+}

--- a/src/main/kotlin/com/wheretopop/domain/project/Project.kt
+++ b/src/main/kotlin/com/wheretopop/domain/project/Project.kt
@@ -1,0 +1,67 @@
+package com.wheretopop.domain.project
+
+import com.wheretopop.domain.user.UserId
+import com.wheretopop.shared.enums.AgeGroup
+import com.wheretopop.shared.enums.BrandScale
+import com.wheretopop.shared.enums.PopUpCategory
+import com.wheretopop.shared.enums.PopUpType
+import java.time.Instant
+
+class Project private constructor(
+    val id: ProjectId,
+    val ownerId: UserId,
+    val name: String,
+    val brandName: String,
+    val popupCategory: PopUpCategory,
+    val popupType: PopUpType,
+    val duration: String,
+    val primaryTargetAgeGroup: AgeGroup,
+    val secondaryTargetAgeGroup: AgeGroup?,
+    val brandScale: BrandScale,
+    val projectGoal: String,
+    val additionalBrandInfo: String?,
+    val additionalProjectInfo: String?,
+    val createdAt: Instant,
+    val updatedAt: Instant,
+    val deletedAt: Instant? = null
+) {
+    companion object {
+        fun create(
+            id: ProjectId,
+            ownerId: UserId,
+            name: String,
+            brandName: String,
+            popupCategory: PopUpCategory,
+            popupType: PopUpType,
+            duration: String,
+            primaryTargetAgeGroup: AgeGroup,
+            secondaryTargetAgeGroup: AgeGroup?,
+            brandScale: BrandScale,
+            projectGoal: String,
+            additionalBrandInfo: String?,
+            additionalProjectInfo: String?,
+            createdAt: Instant,
+            updatedAt: Instant,
+            deletedAt: Instant? = null
+        ): Project {
+            return Project(
+                id,
+                ownerId,
+                name,
+                brandName,
+                popupCategory,
+                popupType,
+                duration,
+                primaryTargetAgeGroup,
+                secondaryTargetAgeGroup,
+                brandScale,
+                projectGoal,
+                additionalBrandInfo,
+                additionalProjectInfo,
+                createdAt,
+                updatedAt,
+                deletedAt
+            )
+        }
+    }
+} 

--- a/src/main/kotlin/com/wheretopop/domain/project/ProjectId.kt
+++ b/src/main/kotlin/com/wheretopop/domain/project/ProjectId.kt
@@ -1,0 +1,19 @@
+package com.wheretopop.domain.project
+
+import com.wheretopop.shared.model.UniqueId
+
+class ProjectId private constructor(
+    value: Long
+) : UniqueId(value) {
+    companion object {
+        @JvmStatic
+        fun create(): ProjectId {
+            return ProjectId(UniqueId.create().value)
+        }
+
+        @JvmStatic
+        fun of(value: Long): ProjectId {
+            return ProjectId(UniqueId.of(value).value)
+        }
+    }
+}

--- a/src/main/kotlin/com/wheretopop/domain/user/User.kt
+++ b/src/main/kotlin/com/wheretopop/domain/user/User.kt
@@ -1,0 +1,35 @@
+package com.wheretopop.domain.user
+
+import java.time.Instant
+
+class User private constructor(
+    val id: UserId,
+    val username: String,
+    val email: String,
+    val profileImageUrl: String?,
+    val createdAt: Instant,
+    val updatedAt: Instant,
+    val deletedAt: Instant? = null
+) {
+    companion object {
+        fun create(
+            id: UserId,
+            username: String,
+            email: String,
+            profileImageUrl: String?,
+            createdAt: Instant,
+            updatedAt: Instant,
+            deletedAt: Instant? = null
+        ): User {
+            return User(
+                id,
+                username,
+                email,
+                profileImageUrl,
+                createdAt,
+                updatedAt,
+                deletedAt
+            )
+        }
+    }
+} 

--- a/src/main/kotlin/com/wheretopop/domain/user/UserId.kt
+++ b/src/main/kotlin/com/wheretopop/domain/user/UserId.kt
@@ -1,0 +1,19 @@
+package com.wheretopop.domain.user
+
+import com.wheretopop.shared.model.UniqueId
+
+class UserId private constructor(
+    value: Long
+) : UniqueId(value) {
+    companion object {
+        @JvmStatic
+        fun create(): UserId {
+            return UserId(UniqueId.create().value)
+        }
+
+        @JvmStatic
+        fun of(value: Long): UserId {
+            return UserId(UniqueId.of(value).value)
+        }
+    }
+}

--- a/src/main/kotlin/com/wheretopop/domain/user/auth/AuthUser.kt
+++ b/src/main/kotlin/com/wheretopop/domain/user/auth/AuthUser.kt
@@ -1,0 +1,63 @@
+package com.wheretopop.domain.user.auth
+
+import com.wheretopop.domain.user.UserId
+import java.time.Instant
+import java.util.UUID
+
+class AuthUser private constructor(
+    val id: AuthUserId,
+    val userId: UserId,
+    val identifier: String,
+    val password: String,
+    val createdAt: Instant,
+    val updatedAt: Instant,
+    val deletedAt: Instant? = null
+) {
+    companion object {
+        fun create(
+            id: AuthUserId,
+            userId: UserId,
+            identifier: String,
+            password: String,
+            createdAt: Instant,
+            updatedAt: Instant,
+            deletedAt: Instant? = null
+        ): AuthUser {
+            return AuthUser(
+                id,
+                userId,
+                identifier,
+                password,
+                createdAt,
+                updatedAt,
+                deletedAt
+            )
+        }
+    }
+    
+    /**
+     * 리프레시 토큰 로테이션(Rotation) 기능
+     * 현재 토큰을 무효화하고 새 토큰 생성
+     */
+    fun rotateRefreshToken(currentToken: RefreshToken, expirationTime: Long): RefreshToken {
+        // 현재 토큰이 이미 만료되었는지 확인
+        if (currentToken.isExpired()) {
+            throw IllegalStateException("토큰이 이미 만료되었습니다")
+        }
+        
+        // 현재 시간 기준으로 새 토큰 생성
+        val now = Instant.now()
+        val expiresAt = now.plusSeconds(expirationTime)
+        
+        // 새 토큰 생성
+        return RefreshToken.create(
+            id = RefreshTokenId.create(),
+            userId = id,
+            token = UUID.randomUUID().toString(),
+            expiresAt = expiresAt,
+            createdAt = now,
+            updatedAt = now,
+            deletedAt = null
+        )
+    }
+} 

--- a/src/main/kotlin/com/wheretopop/domain/user/auth/AuthUserId.kt
+++ b/src/main/kotlin/com/wheretopop/domain/user/auth/AuthUserId.kt
@@ -1,0 +1,19 @@
+package com.wheretopop.domain.user.auth
+
+import com.wheretopop.shared.model.UniqueId
+
+class AuthUserId private constructor(
+    value: Long
+) : UniqueId(value) {
+    companion object {
+        @JvmStatic
+        fun create(): AuthUserId {
+            return AuthUserId(UniqueId.create().value)
+        }
+
+        @JvmStatic
+        fun of(value: Long): AuthUserId {
+            return AuthUserId(UniqueId.of(value).value)
+        }
+    }
+}

--- a/src/main/kotlin/com/wheretopop/domain/user/auth/RefreshToken.kt
+++ b/src/main/kotlin/com/wheretopop/domain/user/auth/RefreshToken.kt
@@ -1,0 +1,49 @@
+package com.wheretopop.domain.user.auth
+
+import java.time.Instant
+
+class RefreshToken private constructor(
+    val id: RefreshTokenId,
+    val userId: AuthUserId,
+    val token: String,
+    val expiresAt: Instant,
+    val createdAt: Instant,
+    val updatedAt: Instant,
+    val deletedAt: Instant? = null
+) {
+    companion object {
+        fun create(
+            id: RefreshTokenId,
+            userId: AuthUserId,
+            token: String,
+            expiresAt: Instant,
+            createdAt: Instant,
+            updatedAt: Instant,
+            deletedAt: Instant? = null
+        ): RefreshToken {
+            return RefreshToken(
+                id,
+                userId,
+                token, 
+                expiresAt,
+                createdAt,
+                updatedAt,
+                deletedAt
+            )
+        }
+    }
+    
+    /**
+     * 토큰이 만료되었는지 확인
+     */
+    fun isExpired(): Boolean {
+        return Instant.now().isAfter(expiresAt) || deletedAt != null
+    }
+    
+    /**
+     * 토큰의 유효성 확인
+     */
+    fun isValid(): Boolean {
+        return !isExpired()
+    }
+} 

--- a/src/main/kotlin/com/wheretopop/domain/user/auth/RefreshTokenId.kt
+++ b/src/main/kotlin/com/wheretopop/domain/user/auth/RefreshTokenId.kt
@@ -1,0 +1,19 @@
+package com.wheretopop.domain.user.auth
+
+import com.wheretopop.shared.model.UniqueId
+
+class RefreshTokenId private constructor(
+    value: Long
+) : UniqueId(value) {
+    companion object {
+        @JvmStatic
+        fun create(): RefreshTokenId {
+            return RefreshTokenId(UniqueId.create().value)
+        }
+
+        @JvmStatic
+        fun of(value: Long): RefreshTokenId {
+            return RefreshTokenId(UniqueId.of(value).value)
+        }
+    }
+}

--- a/src/main/kotlin/com/wheretopop/infrastructure/area/AreaReaderImpl.kt
+++ b/src/main/kotlin/com/wheretopop/infrastructure/area/AreaReaderImpl.kt
@@ -4,7 +4,6 @@ import com.wheretopop.domain.area.Area
 import com.wheretopop.domain.area.AreaCriteria
 import com.wheretopop.domain.area.AreaId
 import com.wheretopop.domain.area.AreaReader
-import com.wheretopop.shared.model.UniqueId
 import org.springframework.stereotype.Component
 
 /**

--- a/src/main/kotlin/com/wheretopop/infrastructure/chat/ChatEntity.kt
+++ b/src/main/kotlin/com/wheretopop/infrastructure/chat/ChatEntity.kt
@@ -1,0 +1,89 @@
+package com.wheretopop.infrastructure.chat
+
+import com.wheretopop.domain.chat.Chat
+import com.wheretopop.domain.chat.ChatId
+import com.wheretopop.infrastructure.chat.message.ChatMessageEntity
+import com.wheretopop.infrastructure.project.ProjectId
+import com.wheretopop.infrastructure.user.UserId
+import org.springframework.core.convert.converter.Converter
+import org.springframework.data.annotation.Id
+import org.springframework.data.annotation.PersistenceCreator
+import org.springframework.data.convert.ReadingConverter
+import org.springframework.data.convert.WritingConverter
+import org.springframework.data.relational.core.mapping.Column
+import org.springframework.data.relational.core.mapping.Table
+import java.time.Instant
+
+
+@Table("chats")
+internal class ChatEntity @PersistenceCreator private constructor(
+    @Id
+    @Column("id")
+    val id: ChatId,
+    @Column("user_id")
+    val userId: UserId,
+    @Column("project_id")
+    val projectId: ProjectId,
+    @Column("title")
+    val title: String,
+    @Column("is_active")
+    val isActive: Boolean,
+    @Column("created_at")
+    val createdAt: Instant,
+    @Column("updated_at")
+    val updatedAt: Instant,
+    @Column("deleted_at")
+    val deletedAt: Instant?
+) {
+    companion object {
+        fun of(chat: Chat): ChatEntity {
+            return ChatEntity(
+                id = chat.id,
+                userId = chat.userId,
+                projectId = chat.projectId,
+                title = chat.title,
+                isActive = chat.isActive,
+                createdAt = chat.createdAt,
+                updatedAt = chat.updatedAt,
+                deletedAt = chat.deletedAt
+            )
+        }
+    }
+
+    fun toDomain(chatMessages: List<ChatMessageEntity>): Chat {
+        return Chat.create(
+            id = id,
+            title = title,
+            userId = userId,
+            projectId = projectId,
+            isActive = isActive,
+            messages = chatMessages.map { it.toDomain() },
+            createdAt = createdAt,
+            updatedAt = updatedAt,
+            deletedAt = deletedAt
+        )
+    }
+
+    fun update(chat: Chat): ChatEntity {
+        return ChatEntity(
+            id = id,
+            title = chat.title,
+            userId = userId,
+            projectId = projectId,
+            isActive = chat.isActive,
+            createdAt = createdAt,
+            updatedAt = Instant.now(),
+            deletedAt = deletedAt
+        )
+    }
+}
+
+@WritingConverter
+class ChatIdToLongConverter : Converter<ChatId, Long> {
+    override fun convert(source: ChatId) = source.toLong()
+}
+
+@ReadingConverter
+class LongToChatIdConverter : Converter<Long, ChatId> {
+    override fun convert(source: Long) = ChatId.of(source)
+}

--- a/src/main/kotlin/com/wheretopop/infrastructure/chat/ai/AiChatClient.kt
+++ b/src/main/kotlin/com/wheretopop/infrastructure/chat/ai/AiChatClient.kt
@@ -1,0 +1,94 @@
+package com.wheretopop.infrastructure.chat.ai
+
+import com.wheretopop.shared.exception.ChatNullResponseException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.reactive.asFlow
+import org.springframework.ai.chat.client.ChatClient
+import org.springframework.ai.chat.messages.Message
+import org.springframework.ai.chat.model.ChatResponse
+import org.springframework.ai.chat.prompt.ChatOptions
+import org.springframework.ai.chat.prompt.Prompt
+import org.springframework.stereotype.Component
+
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.FUNCTION)
+annotation class ExperimentalStream
+
+@Component
+class AiChatClient(private val chatClient: ChatClient) {
+
+    fun call(userPrompt: String): String =
+        chatClient.prompt().user(userPrompt)
+            .call().content() ?: throw ChatNullResponseException()
+
+    fun call(systemPrompt: String?, userPrompt: String): String {
+        val spec = chatClient.prompt().apply {
+            systemPrompt?.let { system(it) }
+            user(userPrompt)
+        }
+        return spec.call().content() ?: throw ChatNullResponseException()
+    }
+
+    fun call(prompt: Prompt): String =
+        chatClient.prompt(prompt).call().content() ?: throw ChatNullResponseException()
+
+    fun call(messages: List<Message>, options: ChatOptions? = null): String {
+        val spec = chatClient.prompt().apply {
+            messages(messages)
+            options?.let { options(it) }
+        }
+        return spec.call().content() ?: throw ChatNullResponseException()
+    }
+
+    fun callWithResponse(userPrompt: String): ChatResponse =
+        chatClient.prompt().user(userPrompt)
+            .call().chatResponse() ?: throw ChatNullResponseException()
+
+    fun callWithResponse(systemPrompt: String?, userPrompt: String): ChatResponse {
+        val spec = chatClient.prompt().apply {
+            systemPrompt?.let { system(it) }
+            user(userPrompt)
+        }
+        return spec.call().chatResponse() ?: throw ChatNullResponseException()
+    }
+
+    fun callWithResponse(prompt: Prompt): ChatResponse =
+        chatClient.prompt(prompt).call().chatResponse() ?: throw ChatNullResponseException()
+
+    fun callWithResponse(messages: List<Message>, options: ChatOptions? = null): ChatResponse {
+        val spec = chatClient.prompt().apply {
+            messages(messages)
+            options?.let { options(it) }
+        }
+        return spec.call().chatResponse() ?: throw ChatNullResponseException()
+    }
+
+    @ExperimentalStream
+    suspend fun stream(userPrompt: String): Flow<ChatResponse> = flow {
+        chatClient.prompt().user(userPrompt)
+            .stream().chatResponse().asFlow().collect { emit(it) }
+    }
+
+    @ExperimentalStream
+    suspend fun stream(systemPrompt: String?, userPrompt: String): Flow<ChatResponse> = flow {
+        chatClient.prompt().apply {
+            systemPrompt?.let { system(it) }
+            user(userPrompt)
+        }.stream().chatResponse().asFlow().collect { emit(it) }
+    }
+
+    @ExperimentalStream
+    suspend fun stream(prompt: Prompt): Flow<ChatResponse> = flow {
+        chatClient.prompt(prompt)
+            .stream().chatResponse().asFlow().collect { emit(it) }
+    }
+
+    @ExperimentalStream
+    suspend fun stream(messages: List<Message>, options: ChatOptions? = null): Flow<ChatResponse> = flow {
+        chatClient.prompt().apply {
+            messages(messages)
+            options?.let { options(it) }
+        }.stream().chatResponse().asFlow().collect { emit(it) }
+    }
+}

--- a/src/main/kotlin/com/wheretopop/infrastructure/chat/message/ChatMessageEntity.kt
+++ b/src/main/kotlin/com/wheretopop/infrastructure/chat/message/ChatMessageEntity.kt
@@ -1,0 +1,93 @@
+package com.wheretopop.infrastructure.chat.message
+
+import com.wheretopop.domain.chat.ChatId
+import com.wheretopop.domain.chat.ChatMessage
+import com.wheretopop.domain.chat.ChatMessageId
+import com.wheretopop.shared.enums.ChatMessageFinishReason
+import com.wheretopop.shared.enums.ChatMessageRole
+import org.springframework.core.convert.converter.Converter
+import org.springframework.data.annotation.Id
+import org.springframework.data.annotation.PersistenceCreator
+import org.springframework.data.convert.ReadingConverter
+import org.springframework.data.convert.WritingConverter
+import org.springframework.data.relational.core.mapping.Column
+import org.springframework.data.relational.core.mapping.Table
+import java.time.Instant
+
+@Table("chat_messages")
+internal class ChatMessageEntity @PersistenceCreator private constructor(
+    @Id
+    @Column("id")
+    val id: ChatMessageId,
+    @Column("chat_id")
+    val chatId: ChatId,
+    @Column("role")
+    val role: ChatMessageRole,
+    @Column("content")
+    val content: String,
+    @Column("finish_reason")
+    val finishReason: ChatMessageFinishReason,
+    @Column("latency_ms")
+    val latencyMs: Long,
+    @Column("created_at")
+    val createdAt: Instant,
+    @Column("updated_at")
+    val updatedAt: Instant,
+    @Column("deleted_at")
+    val deletedAt: Instant?
+) {
+    companion object {
+        fun of(chatMessage: ChatMessage): ChatMessageEntity {
+            return ChatMessageEntity(
+                id = chatMessage.id,
+                chatId = chatMessage.chatId,
+                role = chatMessage.role,
+                content = chatMessage.content,
+                finishReason = chatMessage.finishReason,
+                latencyMs = chatMessage.latencyMs,
+                createdAt = chatMessage.createdAt,
+                updatedAt = chatMessage.updatedAt,
+                deletedAt = chatMessage.deletedAt
+            )
+        }
+    }
+
+    fun toDomain(): ChatMessage {
+        return ChatMessage.create(
+            id = id,
+            chatId = chatId,
+            role = role,
+            content = content,
+            finishReason = finishReason,
+            latencyMs = latencyMs,
+            createdAt = createdAt,
+            updatedAt = updatedAt,
+            deletedAt = deletedAt
+        )
+    }
+
+    fun update(chatMessage: ChatMessage): ChatMessageEntity {
+        return ChatMessageEntity(
+            id = id,
+            chatId = chatId,
+            role = chatMessage.role,
+            content = chatMessage.content,
+            finishReason = chatMessage.finishReason,
+            latencyMs = chatMessage.latencyMs,
+            createdAt = createdAt,
+            updatedAt = Instant.now(),
+            deletedAt = chatMessage.deletedAt
+        )
+    }
+}
+
+
+@WritingConverter
+class ChatMessageIdToLongConverter : Converter<ChatMessageId, Long> {
+    override fun convert(source: ChatMessageId) = source.toLong()
+}
+
+@ReadingConverter
+class LongToChatMessageIdConverter : Converter<Long, ChatMessageId> {
+    override fun convert(source: Long) = ChatMessageId.of(source)
+}

--- a/src/main/kotlin/com/wheretopop/infrastructure/project/ProjectEntity.kt
+++ b/src/main/kotlin/com/wheretopop/infrastructure/project/ProjectEntity.kt
@@ -1,0 +1,130 @@
+package com.wheretopop.infrastructure.project
+
+import com.wheretopop.domain.project.Project
+import com.wheretopop.domain.project.ProjectId
+import com.wheretopop.domain.user.UserId
+import com.wheretopop.shared.enums.AgeGroup
+import com.wheretopop.shared.enums.BrandScale
+import com.wheretopop.shared.enums.PopUpCategory
+import com.wheretopop.shared.enums.PopUpType
+import org.springframework.core.convert.converter.Converter
+import org.springframework.data.annotation.Id
+import org.springframework.data.annotation.PersistenceCreator
+import org.springframework.data.convert.ReadingConverter
+import org.springframework.data.convert.WritingConverter
+import org.springframework.data.relational.core.mapping.Column
+import org.springframework.data.relational.core.mapping.Table
+import java.time.Instant
+
+
+@Table("projects")
+internal class ProjectEntity @PersistenceCreator private constructor(
+    @Id
+    @Column("id")
+    val id: ProjectId,
+    @Column("owner_id")
+    val ownerId: UserId,
+    @Column("name")
+    val name: String,
+    @Column("brand_name")
+    val brandName: String,
+    @Column("popup_category")
+    val popupCategory: PopUpCategory,
+    @Column("popup_type")
+    val popupType: PopUpType,
+    @Column("duration")
+    val duration: String,
+    @Column("primary_target_age_group")
+    val primaryTargetAgeGroup: AgeGroup,
+    @Column("secondary_target_age_group")
+    val secondaryTargetAgeGroup: AgeGroup?,
+    @Column("brand_scale")
+    val brandScale: BrandScale,
+    @Column("project_goal")
+    val projectGoal: String,
+    @Column("additional_brand_info")
+    val additionalBrandInfo: String?,
+    @Column("additional_project_info")
+    val additionalProjectInfo: String?,
+    @Column("created_at")
+    val createdAt: Instant,
+    @Column("updated_at")
+    val updatedAt: Instant,
+    @Column("deleted_at")
+    val deletedAt: Instant?
+) {
+    companion object {
+        fun of(project: Project): ProjectEntity {
+            return ProjectEntity(
+                id = project.id,
+                ownerId = project.ownerId,
+                name = project.name,
+                brandName = project.brandName,
+                popupCategory = project.popupCategory,
+                popupType = project.popupType,
+                duration = project.duration,
+                primaryTargetAgeGroup = project.primaryTargetAgeGroup,
+                secondaryTargetAgeGroup = project.secondaryTargetAgeGroup,
+                brandScale = project.brandScale,
+                projectGoal = project.projectGoal,
+                additionalBrandInfo = project.additionalBrandInfo,
+                additionalProjectInfo = project.additionalProjectInfo,
+                createdAt = project.createdAt,
+                updatedAt = project.updatedAt,
+                deletedAt = project.deletedAt
+            )
+        }
+    }
+
+    fun toDomain(): Project {
+        return Project.create(
+            id = id,
+            ownerId = ownerId,
+            name = name,
+            brandName = brandName,
+            popupCategory = popupCategory,
+            popupType = popupType,
+            duration = duration,
+            primaryTargetAgeGroup = primaryTargetAgeGroup,
+            secondaryTargetAgeGroup = secondaryTargetAgeGroup,
+            brandScale = brandScale,
+            projectGoal = projectGoal,
+            additionalBrandInfo = additionalBrandInfo,
+            additionalProjectInfo = additionalProjectInfo,
+            createdAt = createdAt,
+            updatedAt = updatedAt,
+            deletedAt = deletedAt
+        )
+    }
+
+    fun update(project: Project): ProjectEntity {
+        return ProjectEntity(
+            id = id,
+            ownerId = ownerId,
+            name = project.name,
+            brandName = project.brandName,
+            popupCategory = project.popupCategory,
+            popupType = project.popupType,
+            duration = project.duration,
+            primaryTargetAgeGroup = project.primaryTargetAgeGroup,
+            secondaryTargetAgeGroup = project.secondaryTargetAgeGroup,
+            brandScale = project.brandScale,
+            projectGoal = project.projectGoal,
+            additionalBrandInfo = project.additionalBrandInfo,
+            additionalProjectInfo = project.additionalProjectInfo,
+            createdAt = createdAt,
+            updatedAt = Instant.now(),
+            deletedAt = deletedAt
+        )
+    }
+}
+
+@WritingConverter
+class ProjectIdToLongConverter : Converter<ProjectId, Long> {
+    override fun convert(source: ProjectId) = source.toLong()
+}
+
+@ReadingConverter
+class LongToProjectIdConverter : Converter<Long, ProjectId> {
+    override fun convert(source: Long) = ProjectId.of(source)
+}

--- a/src/main/kotlin/com/wheretopop/infrastructure/user/UserEntity.kt
+++ b/src/main/kotlin/com/wheretopop/infrastructure/user/UserEntity.kt
@@ -1,0 +1,81 @@
+package com.wheretopop.infrastructure.user
+
+import com.wheretopop.domain.user.User
+import com.wheretopop.domain.user.UserId
+import com.wheretopop.shared.model.UniqueId
+import org.springframework.core.convert.converter.Converter
+import org.springframework.data.annotation.Id
+import org.springframework.data.annotation.PersistenceCreator
+import org.springframework.data.convert.ReadingConverter
+import org.springframework.data.convert.WritingConverter
+import org.springframework.data.relational.core.mapping.Column
+import org.springframework.data.relational.core.mapping.Table
+import java.time.Instant
+
+
+@Table("users")
+internal class UserEntity @PersistenceCreator private constructor(
+    @Id
+    @Column("id")
+    val id: UserId,
+    @Column("username")
+    val username: String,
+    @Column("email")
+    val email: String,
+    @Column("profile_image_url")
+    val profileImageUrl: String?,
+    @Column("created_at")
+    val createdAt: Instant,
+    @Column("updated_at")
+    val updatedAt: Instant,
+    @Column("deleted_at")
+    val deletedAt: Instant?
+) {
+    companion object {
+        fun of(user: User): UserEntity {
+            return UserEntity(
+                id = user.id,
+                username = user.username,
+                email = user.email,
+                profileImageUrl = user.profileImageUrl,
+                createdAt = user.createdAt,
+                updatedAt = user.updatedAt,
+                deletedAt = user.deletedAt
+            )
+        }
+    }
+
+    fun toDomain(): User {
+        return User.create(
+            id = id,
+            username = username,
+            email = email,
+            profileImageUrl = profileImageUrl,
+            createdAt = createdAt,
+            updatedAt = updatedAt,
+            deletedAt = deletedAt
+        )
+    }
+
+    fun update(user: User): UserEntity {
+        return UserEntity(
+            id = id,
+            username = user.username,
+            email = user.email,
+            profileImageUrl = user.profileImageUrl,
+            createdAt = createdAt,
+            updatedAt = Instant.now(),
+            deletedAt = deletedAt
+        )
+    }
+}
+
+@WritingConverter
+class UserIdToLongConverter : Converter<UserId, Long> {
+    override fun convert(source: UserId) = source.toLong()
+}
+
+@ReadingConverter
+class LongToUserIdConverter : Converter<Long, UserId> {
+    override fun convert(source: Long) = UserId.of(source)
+}

--- a/src/main/kotlin/com/wheretopop/infrastructure/user/auth/AuthUserEntity.kt
+++ b/src/main/kotlin/com/wheretopop/infrastructure/user/auth/AuthUserEntity.kt
@@ -1,0 +1,81 @@
+package com.wheretopop.infrastructure.user.auth
+
+import com.wheretopop.domain.user.UserId
+import com.wheretopop.domain.user.auth.AuthUser
+import com.wheretopop.domain.user.auth.AuthUserId
+import org.springframework.core.convert.converter.Converter
+import org.springframework.data.annotation.Id
+import org.springframework.data.annotation.PersistenceCreator
+import org.springframework.data.convert.ReadingConverter
+import org.springframework.data.convert.WritingConverter
+import org.springframework.data.relational.core.mapping.Column
+import org.springframework.data.relational.core.mapping.Table
+import java.time.Instant
+
+
+@Table("auth_users")
+internal class AuthUserEntity @PersistenceCreator private constructor(
+    @Id
+    @Column("id")
+    val id: AuthUserId,
+    @Column("user_id")
+    val userId: UserId,
+    @Column("identifier")
+    val identifier: String,
+    @Column("password")
+    val password : String,
+    @Column("created_at")
+    val createdAt: Instant,
+    @Column("updated_at")
+    val updatedAt: Instant,
+    @Column("deleted_at")
+    val deletedAt: Instant?
+) {
+    companion object {
+        fun of(authUser: AuthUser): AuthUserEntity {
+            return AuthUserEntity(
+                id = authUser.id,
+                userId = authUser.userId,
+                identifier = authUser.identifier,
+                password = authUser.password,
+                createdAt = authUser.createdAt,
+                updatedAt = authUser.updatedAt,
+                deletedAt = authUser.deletedAt
+            )
+        }
+    }
+
+    fun toDomain(): AuthUser {
+        return AuthUser.create(
+            id = id,
+            userId = userId,
+            identifier = identifier,
+            password = password,
+            createdAt = createdAt,
+            updatedAt = updatedAt,
+            deletedAt = deletedAt
+        )
+    }
+
+    fun update(authUser: AuthUser): AuthUserEntity {
+        return AuthUserEntity(
+            id = id,
+            userId = userId,
+            identifier = authUser.identifier,
+            password = authUser.password,
+            createdAt = createdAt,
+            updatedAt = Instant.now(),
+            deletedAt = deletedAt
+        )
+    }
+}
+
+@WritingConverter
+class AuthUserIdToLongConverter : Converter<AuthUserId, Long> {
+    override fun convert(source: AuthUserId) = source.toLong()
+}
+
+@ReadingConverter
+class LongToAuthUserIdConverter : Converter<Long, AuthUserId> {
+    override fun convert(source: Long) = AuthUserId.of(source)
+}

--- a/src/main/kotlin/com/wheretopop/infrastructure/user/auth/RefreshTokenEntity.kt
+++ b/src/main/kotlin/com/wheretopop/infrastructure/user/auth/RefreshTokenEntity.kt
@@ -1,0 +1,68 @@
+package com.wheretopop.infrastructure.user.auth
+
+import com.wheretopop.domain.user.auth.AuthUserId
+import com.wheretopop.domain.user.auth.RefreshToken
+import com.wheretopop.domain.user.auth.RefreshTokenId
+import org.springframework.core.convert.converter.Converter
+import org.springframework.data.convert.ReadingConverter
+import org.springframework.data.convert.WritingConverter
+import java.time.Instant
+
+class RefreshTokenEntity(
+    val id: RefreshTokenId,
+    val authUserId: AuthUserId,
+    val token: String,
+    val expiresAt: Instant,
+    val createdAt: Instant,
+    val updatedAt: Instant,
+    val deletedAt: Instant? = null,
+) {
+    companion object {
+        fun of(refreshToken: RefreshToken): RefreshTokenEntity {
+            return RefreshTokenEntity(
+                id = refreshToken.id,
+                authUserId = refreshToken.userId,
+                token = refreshToken.token,
+                expiresAt = refreshToken.expiresAt,
+                createdAt = refreshToken.createdAt,
+                updatedAt = refreshToken.updatedAt,
+                deletedAt = refreshToken.deletedAt,
+
+            )
+        }
+    }
+
+    fun toDomain(): RefreshToken {
+        return RefreshToken.create(
+            id = id,
+            userId = authUserId,
+            token = token,
+            expiresAt = expiresAt,
+            createdAt = createdAt,
+            updatedAt = updatedAt,
+            deletedAt = deletedAt
+        )
+    }
+
+    fun update(refreshToken: RefreshToken): RefreshTokenEntity {
+        return RefreshTokenEntity(
+            id = id,
+            authUserId = authUserId,
+            token = refreshToken.token,
+            expiresAt = refreshToken.expiresAt,
+            createdAt = createdAt,
+            updatedAt = Instant.now(),
+            deletedAt = deletedAt
+        )
+    }
+}
+
+@WritingConverter
+class RefreshTokenIdToLongConverter : Converter<RefreshTokenId, Long> {
+    override fun convert(source: RefreshTokenId) = source.toLong()
+}
+
+@ReadingConverter
+class LongToRefreshTokenIdConverter : Converter<Long, RefreshTokenId> {
+    override fun convert(source: Long) = RefreshTokenId.of(source)
+}

--- a/src/main/kotlin/com/wheretopop/interfaces/chat/ChatApiRouter.kt
+++ b/src/main/kotlin/com/wheretopop/interfaces/chat/ChatApiRouter.kt
@@ -2,56 +2,77 @@ package com.wheretopop.interfaces.chat
 
 import com.wheretopop.application.chat.ChatFacade
 import com.wheretopop.shared.exception.NotImplementedException
+import com.wheretopop.shared.util.SseUtil
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.MediaType
-import org.springframework.http.codec.ServerSentEvent
 import org.springframework.stereotype.Component
-import org.springframework.web.reactive.function.server.ServerRequest
-import org.springframework.web.reactive.function.server.ServerResponse
-import org.springframework.web.reactive.function.server.router
-import reactor.core.publisher.Flux
-import reactor.core.publisher.Mono
-import java.time.Duration
+import org.springframework.web.reactive.function.server.*
+
+/**
+ * 채팅 요청 본문 데이터 클래스
+ */
+data class ChatRequest(
+    val prompt: String,
+    val systemPrompt: String? = null
+)
 
 @Configuration
 class ChatApiRouter(private val chatHandler: ChatHandler) {
-
     @Bean
-    fun chatRoutes() = router {
-        "/v1/chats".nest {
-            accept(MediaType.APPLICATION_JSON).nest {
-                GET("", chatHandler::getChatList)
-                GET("/:chatId", chatHandler::getChat)
-            }
-            accept(MediaType.TEXT_EVENT_STREAM).nest {
-                GET("/:chatId/streams", chatHandler::getChatStream)
+    fun chatRoutes(): RouterFunction<ServerResponse> {
+        return coRouter {
+            "/v1/chats".nest {
+                accept(MediaType.APPLICATION_JSON).nest {
+                    POST("", chatHandler::chat)
+                }
+                accept(MediaType.TEXT_EVENT_STREAM).nest {
+                    GET("/{chatId}/streams", chatHandler::getChatStream)
+                }
             }
         }
     }
 }
 
 @Component
-class ChatHandler(private val chatFacade: ChatFacade) {
-    fun getChat(request: ServerRequest): Mono<ServerResponse> {
+class ChatHandler(
+    private val chatFacade: ChatFacade,
+    private val sseUtil: SseUtil
+) {
+    suspend fun getChat(request: ServerRequest): ServerResponse {
         throw NotImplementedException()
     }
-    fun getChatList(request: ServerRequest): Mono<ServerResponse> {
+    
+    suspend fun getChatList(request: ServerRequest): ServerResponse {
         throw NotImplementedException()
     }
+    
+    // 채팅 요청 처리
+    suspend fun chat(request: ServerRequest): ServerResponse {
+        // 요청 본문에서 ChatRequest 객체로 변환
+        val chatRequest = request.awaitBodyOrNull<ChatRequest>() ?: 
+            ChatRequest(prompt = "기본 프롬프트")
+        
+        // ChatFacade 호출하여 응답 생성
+        val chatResponse = this.chatFacade.chat(chatRequest.prompt)
+        
+        return ServerResponse.ok()
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValueAndAwait(chatResponse)
+    }
+    
+    // 스트림 요청 처리
+    suspend fun getChatStream(request: ServerRequest): ServerResponse {
+        val chatId = request.pathVariable("chatId")
+        
+        // 쿼리 파라미터에서 prompt 가져오기
+        val userPrompt = request.queryParamOrNull("prompt") ?: "현재시간을 알려줘 툴 활용해!"
 
-    fun getChatStream(request: ServerRequest): Mono<ServerResponse> {
-        val eventStream: Flux<ServerSentEvent<String>> =
-            Flux.interval(Duration.ofSeconds(1))
-                .map { tick ->
-                    ServerSentEvent.builder("메시지 #$tick")
-                        .id(tick.toString())
-                        .event("chat-event")
-                        .build()
-                }
+        val generationFlow = chatFacade.streamGenerations(userPrompt)
+        val sseFlow = sseUtil.fromGenerationFlow(generationFlow)
 
         return ServerResponse.ok()
             .contentType(MediaType.TEXT_EVENT_STREAM)
-            .body(eventStream, ServerSentEvent::class.java)
+            .bodyAndAwait(sseFlow)
     }
 }

--- a/src/main/kotlin/com/wheretopop/interfaces/mcp/McpToolRegistry.kt
+++ b/src/main/kotlin/com/wheretopop/interfaces/mcp/McpToolRegistry.kt
@@ -1,0 +1,14 @@
+package com.wheretopop.interfaces.mcp
+
+import org.springframework.ai.tool.annotation.Tool
+import org.springframework.stereotype.Component
+
+@Component
+class McpToolRegistry {
+    @Tool(description = "returns current local date time.")
+    fun now(): String {
+//        return LocalDateTime.now().toString()
+        return "today is 2023-10-01 and 12:00"
+    }
+
+}

--- a/src/main/kotlin/com/wheretopop/shared/enums/BrandSize.kt
+++ b/src/main/kotlin/com/wheretopop/shared/enums/BrandSize.kt
@@ -1,15 +1,9 @@
 package com.wheretopop.shared.enums
 
-enum class BrandSize(
+enum class BrandScale(
     val description: String,
 ) {
     SMALL("소규모(중소)"),
     MEDIUM("중견"),
     LARGE("대기업");
-
-    companion object {
-        fun from(value: String): BrandSize =
-            values().firstOrNull { it.name == value }
-                ?: throw IllegalArgumentException("BrandSize 값($value)에 해당하는 구간이 없습니다.")
-    }
 }

--- a/src/main/kotlin/com/wheretopop/shared/enums/ChatAuthor.kt
+++ b/src/main/kotlin/com/wheretopop/shared/enums/ChatAuthor.kt
@@ -1,0 +1,5 @@
+package com.wheretopop.shared.enums
+
+enum class ChatMessageAuthor(val description: String) {
+    USER("사용자"), CHAT_BOT("챗봇")
+}

--- a/src/main/kotlin/com/wheretopop/shared/enums/ChatAuthor.kt
+++ b/src/main/kotlin/com/wheretopop/shared/enums/ChatAuthor.kt
@@ -1,5 +1,5 @@
 package com.wheretopop.shared.enums
 
-enum class ChatMessageAuthor(val description: String) {
-    USER("사용자"), CHAT_BOT("챗봇")
+enum class ChatMessageRole(val description: String) {
+    USER("사용자"), ASSISTANT("AI 어시스턴트"), SYSTEM("시스템");
 }

--- a/src/main/kotlin/com/wheretopop/shared/enums/ChatMessageFinishReason.kt
+++ b/src/main/kotlin/com/wheretopop/shared/enums/ChatMessageFinishReason.kt
@@ -1,0 +1,13 @@
+package com.wheretopop.shared.enums
+
+/**
+ * 채팅 메시지의 종료 사유를 나타내는 열거형 클래스입니다.
+ * @property description 종료 사유에 대한 설명
+ */
+enum class ChatMessageFinishReason(val description: String) {
+    STOP("정지"),
+    LENGTH("길이 초과"),
+    CONTENT_FILTER("내용 필터링"),
+    TIMEOUT("타임아웃"),
+    ERROR("오류")
+}

--- a/src/main/kotlin/com/wheretopop/shared/exception/ChatNullResponseException.kt
+++ b/src/main/kotlin/com/wheretopop/shared/exception/ChatNullResponseException.kt
@@ -1,0 +1,11 @@
+package com.wheretopop.shared.exception
+
+import com.wheretopop.shared.response.ErrorCode
+
+
+class ChatNullResponseException(
+    message: String? = ErrorCode.CHAT_NULL_RESPONSE.getErrorMsg()
+) : BaseException(
+    message = message,
+    errorCode = ErrorCode.CHAT_NULL_RESPONSE
+)

--- a/src/main/kotlin/com/wheretopop/shared/response/ErrorCode.kt
+++ b/src/main/kotlin/com/wheretopop/shared/response/ErrorCode.kt
@@ -5,7 +5,8 @@ enum class ErrorCode(private val errorMsg: String) {
     COMMON_INVALID_PARAMETER("요청한 값이 올바르지 않습니다."),
     COMMON_ENTITY_NOT_FOUND("존재하지 않는 엔티티입니다."),
     COMMON_ILLEGAL_STATUS("잘못된 상태값입니다."),
-    COMMON_NOT_IMPLEMENTED("구현되지 않은 기능입니다.");
+    COMMON_NOT_IMPLEMENTED("구현되지 않은 기능입니다."),
+    CHAT_NULL_RESPONSE("AI 모델에서 응답을 받지 못했습니다."),;
     fun getErrorMsg(vararg args: Any?): String {
         return if (args.isEmpty()) {
             errorMsg

--- a/src/main/kotlin/com/wheretopop/shared/util/SseUtil.kt
+++ b/src/main/kotlin/com/wheretopop/shared/util/SseUtil.kt
@@ -1,0 +1,39 @@
+package com.wheretopop.shared.util
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import org.springframework.ai.chat.model.Generation
+import org.springframework.http.codec.ServerSentEvent
+import org.springframework.stereotype.Component
+import reactor.core.publisher.Flux
+import java.util.*
+
+@Component
+class SseUtil {
+    fun fromTextFlux(texts: Flux<String>): Flux<ServerSentEvent<String>> {
+        return texts.map { text ->
+            ServerSentEvent.builder(text)
+                .id(UUID.randomUUID().toString())
+                .event("chat-event")
+                .build()
+        }
+    }
+
+    fun fromGenerationFlux(generations: Flux<Generation>): Flux<ServerSentEvent<String>> {
+        return generations.map { generation ->
+            ServerSentEvent.builder(generation.output.text.orEmpty())
+                .id(UUID.randomUUID().toString())
+                .event("chat-event")
+                .build()
+        }
+    }
+
+    fun fromGenerationFlow(generationFlow: Flow<Generation>): Flow<ServerSentEvent<String>> {
+        return generationFlow.map { generation ->
+            ServerSentEvent.builder(generation.output.text.orEmpty())
+                .id(UUID.randomUUID().toString())
+                .event("chat-event")
+                .build()
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,6 +17,43 @@ spring:
         enabled: true
   elasticsearch:
     uris: http://${ES_HOST:localhost}:${ES_PORT:9200}
+  ai:
+    mcp:
+      server:
+        name: where-to-pop
+        type: async
+        sse-endpoint: /mcp/sse
+        sse-message-endpoint: /mcp/message
+        enabled: true
+      client:
+        enabled: true
+        initialized: true
+        request-timeout: 30s
+        toolcallback:
+          enabled: true
+        type: async
+        stdio:
+          connections:
+            filesystem:
+              command: npx
+              args:
+                - "-y"
+                - "@modelcontextprotocol/server-filesystem"
+                - "./"
+
+    openai:
+      api-key: ${OPENAI_API_KEY:your_openai_or_gcp_key}
+      base-url: https://generativelanguage.googleapis.com/v1beta/openai
+#      base-url: https://api.openai.com/v1
+      chat:
+        completions-path: /chat/completions
+        options:
+#          model: gpt-4o
+          model: gemini-2.0-flash
+#        NOTE: gemini에서 api-key를 통한 인증을 java client에서 지원하지 않음. gcp를 통한 인증을 해야함
+#        따라서 https://ai.google.dev/gemini-api/docs/openai?hl=ko openai 호환을 활용해 호출
+#        https://github.com/spring-projects/spring-ai/issues/1252
+
 
 openapi:
   seoul:

--- a/src/main/resources/db/changelog/init.sql
+++ b/src/main/resources/db/changelog/init.sql
@@ -139,3 +139,160 @@ CREATE TABLE IF NOT EXISTS building_registers (
         REFERENCES buildings(id)
         ON DELETE CASCADE
 );
+
+-- 사용자 테이블 생성
+CREATE TABLE IF NOT EXISTS users (
+    id BIGINT PRIMARY KEY,
+    username VARCHAR(255) NOT NULL,
+    email VARCHAR(255) NOT NULL,
+    profile_image_url VARCHAR(2048) DEFAULT NULL,
+    created_at TIMESTAMP(6) NOT NULL,
+    updated_at TIMESTAMP(6) NOT NULL,
+    deleted_at TIMESTAMP(6) DEFAULT NULL,
+    
+    -- 유니크 제약
+    UNIQUE (email),
+    
+    -- 인덱스
+    INDEX idx_users_username (username),
+    INDEX idx_users_email (email),
+    INDEX idx_users_deleted_at (deleted_at)
+);
+
+-- 인증 사용자 테이블 생성
+CREATE TABLE IF NOT EXISTS auth_users (
+    id BIGINT PRIMARY KEY,
+    user_id BIGINT NOT NULL,
+    identifier VARCHAR(255) NOT NULL,
+    password VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP(6) NOT NULL,
+    updated_at TIMESTAMP(6) NOT NULL,
+    deleted_at TIMESTAMP(6) DEFAULT NULL,
+    
+    -- FK 제약
+    CONSTRAINT fk_auth_users_user
+        FOREIGN KEY (user_id)
+        REFERENCES users(id)
+        ON DELETE CASCADE,
+    
+    -- 유니크 제약
+    UNIQUE (identifier),
+    
+    -- 인덱스
+    INDEX idx_auth_users_user_id (user_id),
+    INDEX idx_auth_users_identifier (identifier),
+    INDEX idx_auth_users_deleted_at (deleted_at)
+);
+
+-- 리프레시 토큰 테이블 생성
+CREATE TABLE IF NOT EXISTS refresh_tokens (
+    id BIGINT PRIMARY KEY,
+    auth_user_id BIGINT NOT NULL,
+    token VARCHAR(255) NOT NULL,
+    expires_at TIMESTAMP(6) NOT NULL,
+    created_at TIMESTAMP(6) NOT NULL,
+    updated_at TIMESTAMP(6) NOT NULL,
+    deleted_at TIMESTAMP(6) DEFAULT NULL,
+    
+    -- FK 제약
+    CONSTRAINT fk_refresh_tokens_auth_user
+        FOREIGN KEY (auth_user_id)
+        REFERENCES auth_users(id)
+        ON DELETE CASCADE,
+    
+    -- 유니크 제약
+    UNIQUE (token),
+    
+    -- 인덱스
+    INDEX idx_refresh_tokens_auth_user_id (auth_user_id),
+    INDEX idx_refresh_tokens_token (token),
+    INDEX idx_refresh_tokens_expires_at (expires_at),
+    INDEX idx_refresh_tokens_deleted_at (deleted_at)
+);
+
+-- 프로젝트 테이블 생성
+CREATE TABLE IF NOT EXISTS projects (
+    id BIGINT PRIMARY KEY,
+    owner_id BIGINT NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    brand_name VARCHAR(255) NOT NULL,
+    popup_category VARCHAR(50) NOT NULL,
+    popup_type VARCHAR(50) NOT NULL,
+    duration VARCHAR(100) NOT NULL,
+    primary_target_age_group VARCHAR(50) NOT NULL,
+    secondary_target_age_group VARCHAR(50) DEFAULT NULL,
+    brand_scale VARCHAR(50) NOT NULL,
+    project_goal TEXT NOT NULL,
+    additional_brand_info TEXT DEFAULT NULL,
+    additional_project_info TEXT DEFAULT NULL,
+    created_at TIMESTAMP(6) NOT NULL,
+    updated_at TIMESTAMP(6) NOT NULL,
+    deleted_at TIMESTAMP(6) DEFAULT NULL,
+    
+    -- FK 제약
+    CONSTRAINT fk_projects_owner
+        FOREIGN KEY (owner_id)
+        REFERENCES users(id)
+        ON DELETE CASCADE,
+    
+    -- 인덱스
+    INDEX idx_projects_owner_id (owner_id),
+    INDEX idx_projects_name (name),
+    INDEX idx_projects_brand_name (brand_name),
+    INDEX idx_projects_popup_category (popup_category),
+    INDEX idx_projects_popup_type (popup_type),
+    INDEX idx_projects_deleted_at (deleted_at)
+);
+
+-- 채팅 테이블 생성
+CREATE TABLE IF NOT EXISTS chats (
+    id BIGINT PRIMARY KEY,
+    user_id BIGINT NOT NULL,
+    project_id BIGINT NOT NULL,
+    title VARCHAR(255) NOT NULL,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMP(6) NOT NULL,
+    updated_at TIMESTAMP(6) NOT NULL,
+    deleted_at TIMESTAMP(6) DEFAULT NULL,
+    
+    -- FK 제약
+    CONSTRAINT fk_chats_user
+        FOREIGN KEY (user_id)
+        REFERENCES users(id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_chats_project
+        FOREIGN KEY (project_id)
+        REFERENCES projects(id)
+        ON DELETE CASCADE,
+    
+    -- 인덱스
+    INDEX idx_chats_user_id (user_id),
+    INDEX idx_chats_project_id (project_id),
+    INDEX idx_chats_title (title),
+    INDEX idx_chats_is_active (is_active),
+    INDEX idx_chats_deleted_at (deleted_at)
+);
+
+-- 채팅 메시지 테이블 생성
+CREATE TABLE IF NOT EXISTS chat_messages (
+    id BIGINT PRIMARY KEY,
+    chat_id BIGINT NOT NULL,
+    role VARCHAR(50) NOT NULL,
+    content TEXT NOT NULL,
+    finish_reason VARCHAR(50) NOT NULL,
+    latency_ms BIGINT NOT NULL,
+    created_at TIMESTAMP(6) NOT NULL,
+    updated_at TIMESTAMP(6) NOT NULL,
+    deleted_at TIMESTAMP(6) DEFAULT NULL,
+    
+    -- FK 제약
+    CONSTRAINT fk_chat_messages_chat
+        FOREIGN KEY (chat_id)
+        REFERENCES chats(id)
+        ON DELETE CASCADE,
+    
+    -- 인덱스
+    INDEX idx_chat_messages_chat_id (chat_id),
+    INDEX idx_chat_messages_role (role),
+    INDEX idx_chat_messages_deleted_at (deleted_at)
+);


### PR DESCRIPTION
## 작업내용
spring-ai 의존성을 추가하였습니다.
- open-ai
- mcp-client

를 사용합니다. 또한 jdk21로 올렸습니다.
### vertex 대신 openai 의존성 사용 이유
spring-ai의 vertex 사용하여 gemini 호출 시 api 키 기반 gemini 호출을 지원해주지 않습니다.
gcp 기반으로 인증이 완료된 환경에서만 별도의 키 제공 없이 api 호출을 할 수 있게 해주는데, 클라우드 환경에서 부적합하여 사용하지 않았습니다.
https://ai.google.dev/gemini-api/docs/openai?hl=ko
따라서 위의 openai 명세 호환 gemini api를 활용합니다. spring-openai 패키지를 사용하되, base-url 및 api-key, model 변수 조정을 통해 gemini 및 openai 모델을 바꿔가며 사용할 수 있습니다.

### spring-ai openai에서 gemini를 stream으로 사용 시 NPE 이슈
https://github.com/spring-projects/spring-ai/issues/1252
위 이슈 하단부 참조.
sse를 활용해서 stream으로 gemini를 활용하려 하면, 구글 측 api에서 openai stream 명세의 id라는 값을 주지 않아 NPE가 뜹니다.
따라 스트림으로 활용하는 기능은 명세 구현은 해놓되, gemini 사용 시 활용하면 안됩니다. 이는 spring-ai 버전이 올라가면 해결 될 수 있습니다.
(여유나면 제가 이부분 고쳐서 스프링에 pr올려보겠습니다.)

### MCP 적용 방식에 대한 탐구 및 최종 결정안
spring-ai쪽 chatClient에 mcpClient를 연동하였습니다.
#### 1. 싱글 서버 인스턴스에서 mcp-server과 client 모두 제공
하나의 싱글 서버 인스턴스에서 mcp-server 과 mcp-client를 동시에 열어 client측에서 자기참조로 mcp-server 기능을 활용하도록 하려고 하였으나, 서버가 켜지는 시점에서 mcp-client쪽 초기화가 mcp-server보다 빨리 이루어져 서버 실행이 안되는데, 초기화 시점을 제어할 수 있는 유효한 방법을 찾지 못하여 해당 방법은 사용하지 않습니다.
#### 2. 코틀린 멀티플랫폼을 활용해 클라이언트와 서버 따로 실행
유효한 방법이나 기존 코드베이스를 멀티모듈로 쪼개야 하고 관리해야할 실행환경 대비 득이 적고 로스가 많아 효과적이지 않았습니다.
최종적으로 3번 방식을 찾게되어 기각되었습니다.
#### 3. client 사이드에서 mcp tool 직접 등록하여 provide
mcp 공식 문서에선 찾지 못한 기능이었으나, 아래와 같은 방식으로 class를 정의해두고 안에 @tool를 달아두고 chatClient에 넣어두면 provide가 됩니다.
아래는 spring-ai 프레임워크 구현부 코드입니다.
<img width="821" alt="image" src="https://github.com/user-attachments/assets/a15e5fb7-4a3a-4046-b887-d64488437f0d" />
<img width="732" alt="image" src="https://github.com/user-attachments/assets/97acad7b-d5b3-4d08-8530-b898a41f3f94" />
```java
    public ToolCallback[] getToolCallbacks() {
        ToolCallback[] toolCallbacks = (ToolCallback[])this.toolObjects.stream().map((toolObject) -> {
            return (ToolCallback[])Stream.of(ReflectionUtils.getDeclaredMethods(AopUtils.isAopProxy(toolObject) ? AopUtils.getTargetClass(toolObject) : toolObject.getClass())).filter((toolMethod) -> {
                return toolMethod.isAnnotationPresent(Tool.class);
            }).filter((toolMethod) -> {
                return !this.isFunctionalType(toolMethod);
            }).map((toolMethod) -> {
                return MethodToolCallback.builder().toolDefinition(ToolDefinition.from(toolMethod)).toolMetadata(ToolMetadata.from(toolMethod)).toolMethod(toolMethod).toolObject(toolObject).toolCallResultConverter(ToolUtils.getToolCallResultConverter(toolMethod)).build();
            }).toArray((x$0) -> {
                return new ToolCallback[x$0];
            });
        }).flatMap(Stream::of).toArray((x$0) -> {
            return new ToolCallback[x$0];
        });
        this.validateToolCallbacks(toolCallbacks);
        return toolCallbacks;
    }
```
등록부는 찾았는데, 다만 mcp가 프로토콜이라 이렇게 자바 코드로 된 tool을 등록한다고 해도 이게 별도의 서버가 없는데 내부 client가 사용가능하게 해줄까에 대한 확신은 없어서, 일단 하고 테스트를 해봤습니다.
<img width="1164" alt="image" src="https://github.com/user-attachments/assets/724c263d-86d0-4959-bb7c-fd751459f913" />
<img width="920" alt="image" src="https://github.com/user-attachments/assets/f80cc72d-c57e-457f-9d6d-d2cd00875016" />

놀랍게도 작동합니다.
어떻게 이게 chatClient에서 이용가능한 tools로 작동할 수 있는지는 chatClient의 tool의 정의 및 mcp <-> tools의 관계를 알아봐야 알 수 있을 거 같은데, 일단 작동 확인하여 pr 올립니다.
## 추가) 개선사항 및 비고
https://docs.spring.io/spring-ai/reference/api/tools.html
애초에 spring-ai 부가기능으로 tool-calling이라는 기능 자체가 내장되어있고, LLM의 function-calling 기능 활용하여
mcp와 별개로 작동하며 mcp를 tool-calling을 활용해 적용시킨것 같습니다.
mcp 자체는 function-calling 과정을 외부 서버와 LLM 클라이언트 사이로 표준화된 프로토콜로 진행하는 것이고
애초에 저희의 요구사항에선 mcp 자체가 필요가 없었을 것 같습니다. 
다만, mcp에 유용한 다른 서버들이 많고, mcp 자체가 spring 사이드에서 function-calling 으로 통합을 해주기에 brave search 같은 mcp server는 저희서버에 mcp client만 달아서 이용을 하고 저희 사이드에서 만들어놓은 tool이랑 병합해서 사용하면 좋은 context를 만들어서 넣어줄 수 있을거같습니다.