### PR TITLE
Popup 정보를 Vector DB에 저장

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,11 @@ ES_PORT=9200
 ES_JAVA_OPTS="-Xms512m -Xmx512m"
 # openai API 설정 (gemini 모델 사용해도, openai specification을 따르므로 사용 가능)
 OPENAI_API_KEY=your_api_key_here
+
+# Pinecone 설정
+PINECONE_API_KEY=your_api_key_here
+PINECONE_HOST=your_host_address
+
 # 서울 열린 데이터 광장 설정
 SEOUL_OPEN_DATA_API_KEY=your_api_key_here
 # 대한민국 공공 데이터 포털 설정

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,7 +66,7 @@ dependencies {
 
 
 
-	
+
 	// Bean Validation
 	implementation("org.springframework.boot:spring-boot-starter-validation")
 
@@ -90,6 +90,10 @@ dependencies {
 	implementation("org.seleniumhq.selenium:selenium-java:4.31.0")
 //	implementation("io.github.bonigarcia:webdrivermanager:5.8.0")
 	implementation("org.apache.httpcomponents.client5:httpclient5:5.3.1")
+
+	// for VectorStore
+//	implementation("org.springframework.ai:spring-ai-chroma-store")
+	implementation("org.springframework.ai:spring-ai-starter-vector-store-pinecone")
 
 	// REST Docs
 	testImplementation("org.springframework.restdocs:spring-restdocs-webtestclient")

--- a/src/main/kotlin/com/wheretopop/application/popup/PopplyExternalUseCases.kt
+++ b/src/main/kotlin/com/wheretopop/application/popup/PopplyExternalUseCases.kt
@@ -2,9 +2,12 @@ package com.wheretopop.application.popup
 
 import com.wheretopop.domain.popup.Popup
 import com.wheretopop.domain.popup.PopupId
+import com.wheretopop.domain.popup.PopupInfo
 import com.wheretopop.infrastructure.popup.external.popply.PopupDetail
 
 interface PopplyUseCase {
     suspend fun crawlPopply(): List<PopupDetail>
     suspend fun savePopply(popupDetail: PopupDetail, popupId: PopupId)
+    suspend fun getPopplyList(): List<PopupInfo>
+    suspend fun saveEmbeddedPopply(popupInfos: List<PopupInfo>)
 }

--- a/src/main/kotlin/com/wheretopop/application/popup/PopupFacade.kt
+++ b/src/main/kotlin/com/wheretopop/application/popup/PopupFacade.kt
@@ -17,7 +17,7 @@ class PopupFacade(
     private val popupService: PopupService,
     private val buildingFacade: BuildingFacade,
     private val popplyUseCase: PopplyUseCase,
-    private val xUseCase: XUseCase
+    private val xUseCase: XUseCase,
 ) {
     suspend fun ingestPopupExternalData() {
         val popplyPopupDetails = popplyUseCase.crawlPopply()
@@ -34,5 +34,10 @@ class PopupFacade(
             popplyUseCase.savePopply(popupDetail, newPopup.id)
             xUseCase.crawlXAndSave(newPopup)
         }
+    }
+
+    suspend fun processPopupInfosForVectorSearch() {
+        val popplyPopupInfos = popplyUseCase.getPopplyList()
+        popplyUseCase.saveEmbeddedPopply(popplyPopupInfos)
     }
 }

--- a/src/main/kotlin/com/wheretopop/config/EmbeddingConfig.kt
+++ b/src/main/kotlin/com/wheretopop/config/EmbeddingConfig.kt
@@ -1,0 +1,91 @@
+package com.wheretopop.config
+
+import org.slf4j.LoggerFactory
+import org.springframework.ai.embedding.EmbeddingModel
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.web.reactive.function.client.WebClient
+import reactor.core.publisher.Mono
+
+data class TextPart(val text: String)
+data class EmbeddingContent(val parts: List<TextPart>)
+data class GeminiEmbeddingRequest(
+    val model: String,
+    val content: EmbeddingContent
+)
+data class EmbeddingVector(val values: List<Double>)
+data class GeminiEmbeddingResponse(val embedding: EmbeddingVector)
+
+class GeminiEmbeddingClient(
+    private val webClient: WebClient,
+    private val apiKey: String,
+    private val modelName: String
+) {
+    private val logger = LoggerFactory.getLogger(GeminiEmbeddingClient::class.java)
+
+    fun embed(textToEmbed: String): Mono<List<Double>> {
+        val requestModelIdentifier = "models/$modelName"
+
+        val requestPayload = GeminiEmbeddingRequest(
+            model = requestModelIdentifier,
+            content = EmbeddingContent(parts = listOf(TextPart(text = textToEmbed)))
+        )
+
+        val apiPath = "/$modelName:embedContent"
+
+        return webClient.post()
+            .uri { uriBuilder ->
+                uriBuilder
+                    .path(apiPath)
+                    .queryParam("key", apiKey)
+                    .build()
+            }
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(requestPayload)
+            .retrieve()
+            .bodyToMono(GeminiEmbeddingResponse::class.java)
+            .map { response -> response.embedding.values }
+            .doOnError { error ->
+                logger.error("Error calling Gemini Embedding API for model '$modelName'. URI: '$apiPath', Error: ${error.message}", error)
+            }
+    }
+}
+
+@Configuration
+class EmbeddingConfig {
+
+    @Value("\${spring.ai.openai.api-key}")
+    private lateinit var apiKey: String
+
+    @Value("\${spring.ai.openai.embedding.base-url}")
+    private lateinit var baseUrl: String
+
+    @Value("\${spring.ai.openai.embedding.options.model:gemini-embedding-exp-03-07}")
+    private lateinit var embeddingModelName: String
+
+    @Bean
+    fun geminiApiWebClient(): WebClient {
+        return WebClient.builder()
+            .baseUrl(baseUrl)
+            .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+            .build()
+    }
+
+    @Bean
+    fun geminiEmbeddingClient(geminiApiWebClient: WebClient): GeminiEmbeddingClient {
+        return GeminiEmbeddingClient(
+            webClient = geminiApiWebClient,
+            apiKey = apiKey,
+            modelName = embeddingModelName,
+        )
+    }
+
+    @Bean
+    fun embeddingModel(client: GeminiEmbeddingClient): EmbeddingModel {
+        return SpringAiEmbeddingModelAdapter(client, embeddingModelName)
+    }
+}

--- a/src/main/kotlin/com/wheretopop/config/SpringAiEmbeddingModelAdapter.kt
+++ b/src/main/kotlin/com/wheretopop/config/SpringAiEmbeddingModelAdapter.kt
@@ -1,0 +1,45 @@
+package com.wheretopop.config
+
+import org.springframework.ai.document.Document
+import org.springframework.ai.embedding.Embedding
+import org.springframework.ai.embedding.EmbeddingModel
+import org.springframework.ai.embedding.EmbeddingRequest
+import org.springframework.ai.embedding.EmbeddingResponse
+import org.springframework.util.Assert
+import java.util.HashMap
+
+const val GEMINI_EMBEDDING_DIMENSION = 3024
+
+class SpringAiEmbeddingModelAdapter(
+    private val geminiEmbeddingClient: GeminiEmbeddingClient,
+    private val modelName: String
+) : EmbeddingModel {
+
+    override fun embed(text: String): FloatArray {
+        Assert.hasText(text, "Input text must not be empty")
+        val doubleList: List<Double> = geminiEmbeddingClient.embed(text)
+            .block() ?: throw IllegalStateException("Embedding API call returned null or timed out for text: \"$text\"")
+        return doubleList.map { it.toFloat() }.toFloatArray()
+    }
+
+    override fun embed(document: Document): FloatArray {
+        Assert.notNull(document, "Input document must not be null")
+        return embed(document.text)
+    }
+
+    override fun call(request: EmbeddingRequest): EmbeddingResponse {
+        Assert.notNull(request, "EmbeddingRequest must not be null")
+        Assert.notEmpty(request.instructions, "Input instructions (texts) must not be empty")
+
+        val embeddings = request.instructions.mapIndexed { index, text ->
+            val vector = embed(text)
+            Embedding(vector, index)
+        }
+
+        return EmbeddingResponse(embeddings)
+    }
+
+    override fun dimensions(): Int {
+        return GEMINI_EMBEDDING_DIMENSION
+    }
+}

--- a/src/main/kotlin/com/wheretopop/config/VectorStoreConfig.kt
+++ b/src/main/kotlin/com/wheretopop/config/VectorStoreConfig.kt
@@ -1,0 +1,30 @@
+package com.wheretopop.config
+
+import org.springframework.ai.embedding.EmbeddingModel
+import org.springframework.ai.vectorstore.VectorStore
+import org.springframework.ai.vectorstore.pinecone.PineconeVectorStore
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+
+@Configuration
+class VectorStoreConfig(
+    private val embeddingModel: EmbeddingModel,
+) {
+    @Value("\${spring.ai.vectorstore.pinecone.api-key}")
+    private lateinit var apiKey: String
+
+    @Value("\${spring.ai.vectorstore.pinecone.index-name}")
+    private lateinit var indexName: String
+
+
+    @Bean
+    fun vectorStore(): PineconeVectorStore {
+        return PineconeVectorStore
+            .builder(embeddingModel)
+            .apiKey(apiKey)
+            .indexName(indexName)
+            .build()
+    }
+}

--- a/src/main/kotlin/com/wheretopop/domain/popup/PopupInfo.kt
+++ b/src/main/kotlin/com/wheretopop/domain/popup/PopupInfo.kt
@@ -1,0 +1,21 @@
+package com.wheretopop.domain.popup
+
+data class PopupInfo(
+    val id: Long,
+    val name: String,
+    val address: String,
+    val description: String,
+    val organizerName: String
+) {
+    fun getContentForEmbedding(): String {
+        return listOf(name, address, organizerName, description).joinToString(separator = "\n")
+    }
+
+    fun buildVectorMetadataMap(): Map<String, Any> {
+        return mapOf(
+            "popup_name" to this.name,
+            "address" to this.address,
+            "organizer_name" to this.organizerName,
+        )
+    }
+}

--- a/src/main/kotlin/com/wheretopop/domain/popup/PopupVectorRepository.kt
+++ b/src/main/kotlin/com/wheretopop/domain/popup/PopupVectorRepository.kt
@@ -1,0 +1,5 @@
+package com.wheretopop.domain.popup
+
+interface PopupVectorRepository {
+    suspend fun addPopupInfos(popupInfos: List<PopupInfo>)
+}

--- a/src/main/kotlin/com/wheretopop/infrastructure/popup/external/PopplyExternalManager.kt
+++ b/src/main/kotlin/com/wheretopop/infrastructure/popup/external/PopplyExternalManager.kt
@@ -3,6 +3,7 @@ package com.wheretopop.infrastructure.popup.external
 import com.wheretopop.application.popup.PopplyUseCase
 import com.wheretopop.domain.popup.Popup
 import com.wheretopop.domain.popup.PopupId
+import com.wheretopop.domain.popup.PopupInfo
 import com.wheretopop.infrastructure.popup.external.popply.PopupDetail
 import org.springframework.stereotype.Component
 
@@ -16,5 +17,11 @@ class PopplyExternalManager(
     }
     override suspend fun savePopply(popupDetail: PopupDetail, popupId: PopupId) {
         popupExternalStore.savePopply(popupDetail, popupId)
+    }
+    override suspend fun getPopplyList(): List<PopupInfo> {
+        return popupExternalReader.getAllPopply()
+    }
+    override suspend fun saveEmbeddedPopply(popupInfos: List<PopupInfo>) {
+        return popupExternalStore.saveEmbeddedPopply(popupInfos)
     }
 }

--- a/src/main/kotlin/com/wheretopop/infrastructure/popup/external/PopupExternalReader.kt
+++ b/src/main/kotlin/com/wheretopop/infrastructure/popup/external/PopupExternalReader.kt
@@ -1,4 +1,7 @@
 package com.wheretopop.infrastructure.popup.external
 
+import com.wheretopop.domain.popup.PopupInfo
+
 interface PopupExternalReader {
+    suspend fun getAllPopply():List<PopupInfo>
 }

--- a/src/main/kotlin/com/wheretopop/infrastructure/popup/external/PopupExternalReaderImpl.kt
+++ b/src/main/kotlin/com/wheretopop/infrastructure/popup/external/PopupExternalReaderImpl.kt
@@ -1,7 +1,14 @@
 package com.wheretopop.infrastructure.popup.external
 
+import com.wheretopop.domain.popup.PopupInfo
+import com.wheretopop.infrastructure.popup.external.popply.PopplyProcessor
 import org.springframework.stereotype.Component
 
 @Component
-class PopupExternalReaderImpl: PopupExternalReader {
+class PopupExternalReaderImpl(
+    private val popplyProcessor: PopplyProcessor,
+): PopupExternalReader {
+    override suspend fun getAllPopply(): List<PopupInfo> {
+        return popplyProcessor.getAllPopups()
+    }
 }

--- a/src/main/kotlin/com/wheretopop/infrastructure/popup/external/PopupExternalStore.kt
+++ b/src/main/kotlin/com/wheretopop/infrastructure/popup/external/PopupExternalStore.kt
@@ -2,11 +2,13 @@ package com.wheretopop.infrastructure.popup.external
 
 import com.wheretopop.domain.popup.Popup
 import com.wheretopop.domain.popup.PopupId
+import com.wheretopop.domain.popup.PopupInfo
 import com.wheretopop.infrastructure.popup.external.popply.PopupDetail
 
 interface PopupExternalStore {
     suspend fun crawlPopplyAndSave()
     suspend fun crawlPopply():List<PopupDetail>
     suspend fun savePopply(popupDetail: PopupDetail, popupId: PopupId)
+    suspend fun saveEmbeddedPopply(popupInfos: List<PopupInfo>)
     suspend fun crawlXAndSave(popupId: Popup)
 }

--- a/src/main/kotlin/com/wheretopop/infrastructure/popup/external/PopupExternalStoreImpl.kt
+++ b/src/main/kotlin/com/wheretopop/infrastructure/popup/external/PopupExternalStoreImpl.kt
@@ -2,6 +2,7 @@ package com.wheretopop.infrastructure.popup.external
 
 import com.wheretopop.domain.popup.Popup
 import com.wheretopop.domain.popup.PopupId
+import com.wheretopop.domain.popup.PopupInfo
 import com.wheretopop.infrastructure.popup.external.popply.PopplyProcessor
 import com.wheretopop.infrastructure.popup.external.popply.PopupDetail
 import com.wheretopop.infrastructure.popup.external.x.XProcessor
@@ -10,7 +11,7 @@ import org.springframework.stereotype.Component
 @Component
 class PopupExternalStoreImpl(
     private val popplyProcessor: PopplyProcessor,
-    private val xProcessor: XProcessor
+    private val xProcessor: XProcessor,
 ): PopupExternalStore {
 
     override suspend fun crawlPopplyAndSave() {
@@ -21,6 +22,10 @@ class PopupExternalStoreImpl(
     }
     override suspend fun savePopply(popupDetail: PopupDetail, popupId: PopupId) {
         popplyProcessor.save(popupDetail, popupId)
+    }
+
+    override suspend fun saveEmbeddedPopply(popupInfos: List<PopupInfo>) {
+        popplyProcessor.saveEmbeddings(popupInfos)
     }
     override suspend fun crawlXAndSave(popup: Popup) {
         xProcessor.crawlAndSaveByPopup(popup)

--- a/src/main/kotlin/com/wheretopop/infrastructure/popup/external/PopupVectorRepositoryImpl.kt
+++ b/src/main/kotlin/com/wheretopop/infrastructure/popup/external/PopupVectorRepositoryImpl.kt
@@ -1,0 +1,63 @@
+package com.wheretopop.infrastructure.popup.external
+
+import com.wheretopop.domain.popup.PopupInfo
+import com.wheretopop.domain.popup.PopupVectorRepository
+import kotlinx.coroutines.delay
+import mu.KotlinLogging
+import org.springframework.ai.document.Document
+import org.springframework.ai.vectorstore.VectorStore
+import org.springframework.stereotype.Repository
+import org.springframework.web.reactive.function.client.WebClientResponseException
+
+private val logger = KotlinLogging.logger {}
+
+@Repository
+class PopupVectorRepositoryImpl(
+    private val vectorStore: VectorStore
+): PopupVectorRepository {
+    override suspend fun addPopupInfos(popupInfos: List<PopupInfo>) {
+//        val documents:List<Document> = popupInfos.map { info -> Document(
+//                info.id.toString(),
+//                info.getContentForEmbedding(),
+//                info.buildVectorMetadataMap()
+//            )
+//        }
+//        vectorStore.add(documents)
+        addPopupInfosInChunks(popupInfos)
+    }
+
+    suspend fun addPopupInfosInChunks(popupInfos: List<PopupInfo>, chunkSize: Int = 2, delayBetweenChunksMillis: Long = 5000L) {
+        popupInfos.chunked(chunkSize).forEach { chunk ->
+            val documentsForChunk: List<Document> = chunk.map { info ->
+                Document(
+                    info.id.toString(),
+                    info.getContentForEmbedding(),
+                    info.buildVectorMetadataMap()
+                )
+            }
+
+            var Succeeded = false
+            var retries = 3
+            var waitTime = 1000L
+
+            while(retries > 0 && !Succeeded) {
+                try {
+                    vectorStore.add(documentsForChunk)
+                    Succeeded = true
+                    logger.info("${chunk.size}개 문서 청크 처리 성공.")
+                } catch (e: WebClientResponseException.TooManyRequests) {
+                    logger.warn("429 오류. ${waitTime/1000}초 후 재시도...")
+                    delay(waitTime)
+                    waitTime *= 2
+                    retries--
+                    if(retries == 0) throw e
+                }
+            }
+
+            if (popupInfos.size > chunkSize) { // 마지막 청크가 아닐 경우
+                logger.info("${delayBetweenChunksMillis/1000}초 후 다음 청크 처리 시작...")
+                delay(delayBetweenChunksMillis)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/wheretopop/infrastructure/popup/external/popply/PopplyProcessor.kt
+++ b/src/main/kotlin/com/wheretopop/infrastructure/popup/external/popply/PopplyProcessor.kt
@@ -1,6 +1,7 @@
 package com.wheretopop.infrastructure.popup.external.popply
 
 import com.wheretopop.domain.popup.PopupId
+import com.wheretopop.domain.popup.PopupInfo
 
 /**
  * 팝플리에서 정보를 크롤링하고, 이를 가공하여 Popup 도메인에 맞는 형태로 변환하는 책임
@@ -9,4 +10,6 @@ interface PopplyProcessor {
     suspend fun crawlAndSave()
     suspend fun crawl(): List<PopupDetail>
     suspend fun save(popupDetail: PopupDetail, popupId: PopupId)
+    suspend fun saveEmbeddings(popupInfos: List<PopupInfo>)
+    suspend fun getAllPopups(): List<PopupInfo>
 }

--- a/src/main/kotlin/com/wheretopop/infrastructure/popup/external/popply/PopupPopplyEntity.kt
+++ b/src/main/kotlin/com/wheretopop/infrastructure/popup/external/popply/PopupPopplyEntity.kt
@@ -1,6 +1,6 @@
 package com.wheretopop.infrastructure.popup.external.popply
 
-import com.wheretopop.domain.popup.PopupId
+import com.wheretopop.domain.popup.PopupInfo
 import com.wheretopop.shared.model.UniqueId
 import org.springframework.core.convert.converter.Converter
 import org.springframework.data.annotation.Id
@@ -100,6 +100,16 @@ data class PopupPopplyEntity(
                 popplyId = popupDetail.popplyId,
                 createdAt = Instant.now(),
                 updatedAt = Instant.now()
+            )
+        }
+
+        fun toDomain(entity: PopupPopplyEntity): PopupInfo {
+            return PopupInfo(
+                id = entity.popupId,
+                name = entity.popupName,
+                address = entity.address,
+                description = entity.description,
+                organizerName = entity.organizerName ?: ""
             )
         }
     }

--- a/src/main/kotlin/com/wheretopop/infrastructure/popup/external/popply/PopupPopplyProcessor.kt
+++ b/src/main/kotlin/com/wheretopop/infrastructure/popup/external/popply/PopupPopplyProcessor.kt
@@ -2,9 +2,10 @@ package com.wheretopop.infrastructure.popup.external.popply
 
 import com.wheretopop.domain.popup.Popup
 import com.wheretopop.domain.popup.PopupId
+import com.wheretopop.domain.popup.PopupInfo
+import com.wheretopop.domain.popup.PopupVectorRepository
 import com.wheretopop.infrastructure.popup.PopupRepository
 import mu.KotlinLogging
-import org.bouncycastle.asn1.cmc.CMCStatus.success
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 
@@ -20,6 +21,7 @@ class PopupPopplyProcessor(
     private val popupPopplyRepository: PopupPopplyRepository,
     private val popupRepository: PopupRepository,
     private val popupListCrawler: PopupListCrawler,
+    private val popupVectorRepository: PopupVectorRepository
 ) : PopplyProcessor {
 
     override suspend fun crawlAndSave() {
@@ -40,6 +42,14 @@ class PopupPopplyProcessor(
             popupId = popupId.toLong(),
         )
         popupPopplyRepository.save(popupPopplyEntity)
+    }
+
+    override suspend fun saveEmbeddings(popupInfos: List<PopupInfo>) {
+        popupVectorRepository.addPopupInfos(popupInfos)
+    }
+
+    override suspend fun getAllPopups(): List<PopupInfo> {
+        return popupPopplyRepository.findAll()
     }
 
     suspend fun getPopupDetail(popplyId: Int): PopupDetail? {

--- a/src/main/kotlin/com/wheretopop/infrastructure/popup/external/popply/PopupPopplyRepository.kt
+++ b/src/main/kotlin/com/wheretopop/infrastructure/popup/external/popply/PopupPopplyRepository.kt
@@ -1,10 +1,12 @@
 package com.wheretopop.infrastructure.popup.external.popply
 
 import com.wheretopop.domain.popup.PopupId
+import com.wheretopop.domain.popup.PopupInfo
 
 interface PopupPopplyRepository {
     suspend fun save(entity: PopupPopplyEntity): PopupPopplyEntity
     suspend fun save(entities: List<PopupPopplyEntity>): List<PopupPopplyEntity>
+    suspend fun findAll(): List<PopupInfo>
     suspend fun findByPopplyId(popplyId: Int): PopupPopplyEntity?
     suspend fun findByPopupId(popupId: PopupId): PopupPopplyEntity?
 }

--- a/src/main/kotlin/com/wheretopop/infrastructure/popup/external/popply/R2dbcPopupPopplyRepository.kt
+++ b/src/main/kotlin/com/wheretopop/infrastructure/popup/external/popply/R2dbcPopupPopplyRepository.kt
@@ -1,6 +1,7 @@
 package com.wheretopop.infrastructure.popup.external.popply
 
 import com.wheretopop.domain.popup.PopupId
+import com.wheretopop.domain.popup.PopupInfo
 import kotlinx.coroutines.reactor.awaitSingle
 import kotlinx.coroutines.reactor.awaitSingleOrNull
 import org.springframework.data.r2dbc.core.R2dbcEntityTemplate
@@ -24,6 +25,13 @@ internal class R2dbcPopupPopplyRepository (
 
     override suspend fun save(entities: List<PopupPopplyEntity>): List<PopupPopplyEntity> =
         entities.map { save(it) }
+
+    override suspend fun findAll(): List<PopupInfo> =
+        entityTemplate.select(entityClass)
+            .all()
+            .map(PopupPopplyEntity::toDomain)
+            .collectList()
+            .awaitSingle()
 
     override suspend fun findByPopupId(popupId: PopupId): PopupPopplyEntity? =
         entityTemplate

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,6 +45,27 @@ spring:
 #        NOTE: gemini에서 api-key를 통한 인증을 java client에서 지원하지 않음. gcp를 통한 인증을 해야함
 #        따라서 https://ai.google.dev/gemini-api/docs/openai?hl=ko openai 호환을 활용해 호출
 #        https://github.com/spring-projects/spring-ai/issues/1252
+      embedding:
+        base-url: https://generativelanguage.googleapis.com/v1beta/models
+        options:
+#          model: text-embedding-ada-002
+          model: gemini-embedding-exp-03-07
+
+
+
+    vectorstore:
+      chroma:
+        client:
+          host: localhost
+          port: 8000
+        collection-name: popup_reviews
+        initialize-schema: true
+
+      pinecone:
+        api-key: ${PINECONE_API_KEY:pinecone_key}
+        host: ${PINECONE_HOST:pinecone_host}
+        index-name: popup-infos
+
 
 
 openapi:


### PR DESCRIPTION
## 변경 사항
- 멘토님의 조언에 따라 팝업 리뷰 -> 팝업 정보(`description`, `popup_name`, `address`, `organizer_name`) 를 불러오는 것으로 수정했습니다.
    > 쿼리에 맞는 팝업을 불러오려면 의미있는 정보를 vector db에 넣어야 함
    - 사실 이것도 많이 부족한 정보긴 합니다만... 일단은 최소한의 정보로 작동하는지 확인 후 정보를 붙여나갈 예정입니다. 
- **embeddingModel**
    `spring-ai`에서 제공하는 것으로 했더니 gemini 연결이 계속 안돼서 -> 직접 HTTP 연결하는 것으로 변경
- **Vector DB**
    `spring-ai`에서 제공되는 `pinecone` 라이브러리 사용
    근데 build할 때 `spring-ai`의 embeddingModel 형식을 원해서 위 HTTP 연결하는 모델에 어댑터 달아서 반환

<br/>

## pinecone에 저장된 데이터
![image](https://github.com/user-attachments/assets/7882ede8-98b8-435c-b404-3e7fa0b10e94)

## 할 일
- [ ] query로 비슷한 팝업 찾아오는 로직
- [ ] 주기적 | 크롤러가 팝업 정보 가져올 때, vector에 업로드하도록 수정
 