### PR TITLE
feat: area 관련 tool registry

### DIFF
--- a/src/main/kotlin/com/wheretopop/application/area/AreaFacade.kt
+++ b/src/main/kotlin/com/wheretopop/application/area/AreaFacade.kt
@@ -1,9 +1,10 @@
 package com.wheretopop.application.area
 
 import com.wheretopop.domain.area.AreaCriteria
+import com.wheretopop.domain.area.AreaId
 import com.wheretopop.domain.area.AreaInfo
 import com.wheretopop.domain.area.AreaService
-import com.wheretopop.infrastructure.area.external.AreaExternalStore
+import mu.KotlinLogging
 import org.springframework.stereotype.Service
 
 /**
@@ -15,11 +16,24 @@ class AreaFacade(
     private val areaService: AreaService,
     private val areaOpenDataUseCase: AreaOpenDataUseCase
 ) {
+    private val logger = KotlinLogging.logger {}
+
     /**
      * 필터 조건으로 지역 검색
      */
     suspend fun searchAreas(criteria: AreaCriteria.SearchAreaCriteria): List<AreaInfo.Main> {
         return areaService.searchAreas(criteria)
+    }
+
+    suspend fun findAll(): List<AreaInfo.Main> {
+        logger.info { "findAll() 호출" }
+        val value =  areaService.findAll()
+        logger.info { "findAll() - ${value.size}개 지역 정보 조회" }
+        return value
+    }
+
+    suspend fun getAreaDetailById(areaId: AreaId): AreaInfo.Detail? {
+        return areaService.getAreaDetailById(areaId)
     }
 
     suspend fun ingestAreaExternalData() {

--- a/src/main/kotlin/com/wheretopop/config/ChatClientConfig.kt
+++ b/src/main/kotlin/com/wheretopop/config/ChatClientConfig.kt
@@ -1,6 +1,6 @@
 package com.wheretopop.config
 
-import com.wheretopop.infrastructure.chat.AiToolRegistry
+import com.wheretopop.interfaces.area.AreaToolRegistry
 import io.modelcontextprotocol.client.McpAsyncClient
 import org.slf4j.LoggerFactory
 import org.springframework.ai.chat.client.ChatClient
@@ -14,7 +14,7 @@ import org.springframework.context.annotation.Configuration
 @Configuration
 class ChatClientConfig(
     private val chatModel: ChatModel,
-    private val aiToolRegistry: AiToolRegistry,
+    private val areaToolRegistry: AreaToolRegistry,
     private val asyncClients : List<McpAsyncClient>
 ){
 
@@ -26,7 +26,7 @@ class ChatClientConfig(
     fun chatClient(): ChatClient {
         val mcpToolCallbacks: List<ToolCallback> = McpToolUtils.getToolCallbacksFromAsyncClients(asyncClients);
         return ChatClient.builder(chatModel)
-            .defaultTools(aiToolRegistry, mcpToolCallbacks)
+            .defaultTools(areaToolRegistry, mcpToolCallbacks)
             .build()
     }
 }

--- a/src/main/kotlin/com/wheretopop/domain/area/AreaId.kt
+++ b/src/main/kotlin/com/wheretopop/domain/area/AreaId.kt
@@ -15,5 +15,10 @@ class AreaId private constructor(
         fun of(value: Long): AreaId {
             return AreaId(UniqueId.of(value).value)
         }
+
+        @JvmStatic
+        fun of(value: String): AreaId {
+            return AreaId(UniqueId.of(value).value)
+        }
     }
 }

--- a/src/main/kotlin/com/wheretopop/domain/area/AreaInfo.kt
+++ b/src/main/kotlin/com/wheretopop/domain/area/AreaInfo.kt
@@ -1,5 +1,7 @@
 package com.wheretopop.domain.area
 
+import java.time.Instant
+
 /**
  * 도메인 계층 외부에 넘겨줄 Area 관련 DTO 클래스들
  * 도메인 로직이 누설되지 않도록 데이터만 전달
@@ -16,6 +18,14 @@ class AreaInfo {
         val description: String?,
         val location: LocationInfo,
     )
+
+    data class Detail(
+        val id: AreaId,
+        val name: String,
+        val description: String?,
+        val location: LocationInfo,
+        val populationInsight: PopulationInsight?
+    )
     
     /**
      * Location 정보를 담은 DTO
@@ -23,5 +33,70 @@ class AreaInfo {
     data class LocationInfo(
         val latitude: Double,
         val longitude: Double
+    )
+    
+    /**
+     * 지역 인구 데이터 인사이트를 담은 DTO
+     */
+    data class PopulationInsight(
+        val areaId: AreaId,
+        val areaName: String,
+        val congestionLevel: String,
+        val congestionMessage: String,
+        val currentPopulation: Int,              // 현재 추정 인구 수
+        val populationDensity: PopulationDensity,
+        val demographicInsight: DemographicInsight,
+        val peakTimes: List<PeakTimeInfo>,       // 인구 피크 시간대 정보
+        val lastUpdatedAt: Instant               // 데이터 최종 업데이트 시간
+    )
+    
+    /**
+     * 인구 밀집도 정보
+     */
+    data class PopulationDensity(
+        val level: String,                       // 낮음, 보통, 높음, 매우 높음
+        val residentRate: Double,                // 거주자 비율
+        val nonResidentRate: Double              // 비거주자 비율 (외지인/관광객)
+    )
+    
+    /**
+     * 인구 통계학적 인사이트
+     */
+    data class DemographicInsight(
+        val genderRatio: GenderRatio,
+        val ageDistribution: AgeDistribution,
+        val mainVisitorGroup: String             // 주요 방문자 그룹 (예: "20-30대 여성")
+    )
+    
+    /**
+     * 성별 비율
+     */
+    data class GenderRatio(
+        val maleRate: Double,
+        val femaleRate: Double
+    )
+    
+    /**
+     * 연령대별 분포
+     */
+    data class AgeDistribution(
+        val under10Rate: Double,
+        val age10sRate: Double,
+        val age20sRate: Double,
+        val age30sRate: Double,
+        val age40sRate: Double,
+        val age50sRate: Double,
+        val age60sRate: Double,
+        val over70sRate: Double,
+        val dominantAgeGroup: String             // 가장 비율이 높은 연령대
+    )
+    
+    /**
+     * 인구 피크 시간 정보
+     */
+    data class PeakTimeInfo(
+        val hour: Int,                           // 시간 (0-23)
+        val expectedCongestion: String,          // 예상 혼잡도
+        val populationEstimate: Int              // 예상 인구 수
     )
 }

--- a/src/main/kotlin/com/wheretopop/domain/area/AreaInfoMapper.kt
+++ b/src/main/kotlin/com/wheretopop/domain/area/AreaInfoMapper.kt
@@ -27,4 +27,19 @@ class AreaInfoMapper {
         return domains.map(::of)
     }
 
+    /**
+     * Area 도메인 객체와 AreaInsight 도메인 객체를 AreaInfo.Detail DTO로 변환
+     */
+    fun of(domain: Area, areaInsight: AreaInfo.PopulationInsight?): AreaInfo.Detail {
+        return AreaInfo.Detail(
+            id = domain.id,
+            name = domain.name,
+            description = domain.description,
+            location = AreaInfo.LocationInfo(
+                latitude = domain.location.latitude,
+                longitude = domain.location.longitude
+            ),
+            populationInsight = areaInsight,
+        )
+    }
 }

--- a/src/main/kotlin/com/wheretopop/domain/area/AreaInsightProvider.kt
+++ b/src/main/kotlin/com/wheretopop/domain/area/AreaInsightProvider.kt
@@ -1,9 +1,6 @@
-package com.wheretopop.infrastructure.area.external
+package com.wheretopop.domain.area
 
-import com.wheretopop.domain.area.AreaId
-import com.wheretopop.domain.area.AreaInfo
-
-interface AreaExternalReader {
+interface AreaInsightProvider{
     suspend fun findPopulationInsightByAreaId(areaId: AreaId): AreaInfo.PopulationInsight?
     suspend fun findPopulationInsightsByAreaIds(areaIds: List<AreaId>): List<AreaInfo.PopulationInsight>
 }

--- a/src/main/kotlin/com/wheretopop/domain/area/AreaService.kt
+++ b/src/main/kotlin/com/wheretopop/domain/area/AreaService.kt
@@ -2,4 +2,6 @@ package com.wheretopop.domain.area
 
 interface AreaService {
     suspend fun searchAreas(criteria: AreaCriteria.SearchAreaCriteria): List<AreaInfo.Main>
+    suspend fun findAll(): List<AreaInfo.Main>
+    suspend fun getAreaDetailById(id: AreaId): AreaInfo.Detail
 }

--- a/src/main/kotlin/com/wheretopop/domain/area/AreaServiceImpl.kt
+++ b/src/main/kotlin/com/wheretopop/domain/area/AreaServiceImpl.kt
@@ -1,10 +1,13 @@
 package com.wheretopop.domain.area
+import com.wheretopop.shared.exception.toException
+import com.wheretopop.shared.response.ErrorCode
 import org.springframework.stereotype.Service
 
 @Service
 class AreaServiceImpl(
     private val areaReader: AreaReader,
     private val areaStore: AreaStore,
+    private val areaInsightProvider: AreaInsightProvider,
 ) : AreaService {
 
     private val areaInfoMapper = AreaInfoMapper()
@@ -13,4 +16,15 @@ class AreaServiceImpl(
         val areas = this.areaReader.findAreas(criteria);
         return areaInfoMapper.of(areas);
     }
+    override suspend fun findAll(): List<AreaInfo.Main> {
+        val areas = this.areaReader.findAll();
+        return areaInfoMapper.of(areas);
+    }
+
+    override suspend fun getAreaDetailById(id: AreaId): AreaInfo.Detail {
+        val area = this.areaReader.findById(id) ?: throw ErrorCode.COMMON_ENTITY_NOT_FOUND.toException();
+        val areaPopulationInsight = this.areaInsightProvider.findPopulationInsightByAreaId(id) ;
+        return areaInfoMapper.of(area, areaPopulationInsight);
+    }
+
 }

--- a/src/main/kotlin/com/wheretopop/infrastructure/area/external/AreaExternalManager.kt
+++ b/src/main/kotlin/com/wheretopop/infrastructure/area/external/AreaExternalManager.kt
@@ -1,15 +1,26 @@
 package com.wheretopop.infrastructure.area.external
 
-import org.springframework.stereotype.Component
 import com.wheretopop.application.area.AreaOpenDataUseCase
 import com.wheretopop.application.area.AreaSnsUseCase
+import com.wheretopop.domain.area.AreaId
+import com.wheretopop.domain.area.AreaInfo
+import com.wheretopop.domain.area.AreaInsightProvider
+import org.springframework.stereotype.Component
 
 @Component
 class AreaExternalManager(
     private val areaExternalStore: AreaExternalStore,
     private val areaExternalReader: AreaExternalReader
-): AreaOpenDataUseCase, AreaSnsUseCase {
+): AreaOpenDataUseCase, AreaSnsUseCase, AreaInsightProvider {
     override suspend fun callOpenDataApiAndSave() {
         return areaExternalStore.callOpenDataApiAndSave()
+    }
+
+    override suspend fun findPopulationInsightByAreaId(areaId: AreaId): AreaInfo.PopulationInsight? {
+        return areaExternalReader.findPopulationInsightByAreaId(areaId)
+    }
+
+    override suspend fun findPopulationInsightsByAreaIds(areaIds: List<AreaId>): List<AreaInfo.PopulationInsight> {
+        return areaExternalReader.findPopulationInsightsByAreaIds(areaIds)
     }
 }

--- a/src/main/kotlin/com/wheretopop/infrastructure/area/external/AreaExternalReaderImpl.kt
+++ b/src/main/kotlin/com/wheretopop/infrastructure/area/external/AreaExternalReaderImpl.kt
@@ -1,7 +1,19 @@
 package com.wheretopop.infrastructure.area.external
 
+import com.wheretopop.domain.area.AreaId
+import com.wheretopop.domain.area.AreaInfo
+import com.wheretopop.infrastructure.area.external.opendata.population.AreaPopulationRepository
 import org.springframework.stereotype.Component
 
 @Component
-class AreaExternalReaderImpl: AreaExternalReader {
+class AreaExternalReaderImpl (
+    private val areaPopulationRepository: AreaPopulationRepository,
+) : AreaExternalReader {
+    override suspend fun findPopulationInsightByAreaId(areaId: AreaId): AreaInfo.PopulationInsight? {
+        return areaPopulationRepository.findPopulationInsightByAreaId(areaId)
+    }
+
+    override suspend fun findPopulationInsightsByAreaIds(areaIds: List<AreaId>): List<AreaInfo.PopulationInsight> {
+        return areaPopulationRepository.findPopulationInsightsByAreaIds(areaIds)
+    }
 }

--- a/src/main/kotlin/com/wheretopop/infrastructure/area/external/opendata/population/AreaPopulationRepository.kt
+++ b/src/main/kotlin/com/wheretopop/infrastructure/area/external/opendata/population/AreaPopulationRepository.kt
@@ -1,6 +1,12 @@
 package com.wheretopop.infrastructure.area.external.opendata.population
 
+import com.wheretopop.domain.area.AreaId
+import com.wheretopop.domain.area.AreaInfo
+
 interface AreaPopulationRepository {
     suspend fun save(entity: AreaPopulationEntity): AreaPopulationEntity
     suspend fun save(entities: List<AreaPopulationEntity>): List<AreaPopulationEntity>
+    suspend fun findLatestByAreaId(areaId: AreaId): AreaPopulationEntity?
+    suspend fun findPopulationInsightByAreaId(areaId: AreaId): AreaInfo.PopulationInsight?
+    suspend fun findPopulationInsightsByAreaIds(areaIds: List<AreaId>): List<AreaInfo.PopulationInsight>
 }

--- a/src/main/kotlin/com/wheretopop/infrastructure/area/external/opendata/population/R2dbcAreaPopulationRepository.kt
+++ b/src/main/kotlin/com/wheretopop/infrastructure/area/external/opendata/population/R2dbcAreaPopulationRepository.kt
@@ -1,17 +1,22 @@
 package com.wheretopop.infrastructure.area.external.opendata.population
 
+import com.wheretopop.domain.area.AreaId
+import com.wheretopop.domain.area.AreaInfo
 import kotlinx.coroutines.reactor.awaitSingle
 import kotlinx.coroutines.reactor.awaitSingleOrNull
+import org.springframework.data.domain.Sort
 import org.springframework.data.r2dbc.core.R2dbcEntityTemplate
+import org.springframework.data.r2dbc.core.awaitFirstOrNull
 import org.springframework.data.relational.core.query.Criteria.where
 import org.springframework.data.relational.core.query.Query.query
+import java.time.ZoneId
+
 
 internal class R2dbcAreaPopulationRepository(
-    private val entityTemplate: R2dbcEntityTemplate
+    private val entityTemplate: R2dbcEntityTemplate,
 ) : AreaPopulationRepository {
 
     private val entityClass = AreaPopulationEntity::class.java
-
 
     override suspend fun save(entity: AreaPopulationEntity): AreaPopulationEntity {
         val existing = loadEntityById(entity.id)
@@ -25,6 +30,164 @@ internal class R2dbcAreaPopulationRepository(
     override suspend fun save(entities: List<AreaPopulationEntity>): List<AreaPopulationEntity> =
         entities.map { save(it) }
 
+    override suspend fun findLatestByAreaId(areaId: AreaId): AreaPopulationEntity? =
+        entityTemplate
+            .select(entityClass)
+            .matching(
+                query(
+                    where("area_id").`is`(areaId)
+                        .and("deleted_at").isNull
+                ).sort(Sort.by(Sort.Direction.DESC, "population_update_time"))
+            )
+            .awaitFirstOrNull()
+
+    /**
+     * 지역 ID를 기반으로 인구 데이터 인사이트를 도출합니다.
+     */
+    override suspend fun findPopulationInsightByAreaId(areaId: AreaId): AreaInfo.PopulationInsight? {
+        // 최신 인구 데이터 조회
+        val latestData = findLatestByAreaId(areaId) ?: return null
+        
+        // 예측 데이터 파싱
+        val forecastData = latestData.getForecastPopulations() ?: emptyList()
+        
+        // 피크 타임 정보 추출
+        val peakTimes = extractPeakTimes(forecastData)
+        
+        // 주요 방문자 그룹 분석
+        val mainVisitorGroup = determineMainVisitorGroup(latestData)
+        
+        // 지배적 연령대 확인
+        val dominantAgeGroup = determineDominantAgeGroup(latestData)
+        
+        // 현재 추정 인구수 (최소값과 최대값의 평균)
+        val currentPopulation = (latestData.populationMin + latestData.populationMax) / 2
+        
+        return AreaInfo.PopulationInsight(
+            areaId = latestData.areaId,
+            areaName = latestData.areaName,
+            congestionLevel = latestData.congestionLevel,
+            congestionMessage = latestData.congestionMessage,
+            currentPopulation = currentPopulation,
+            populationDensity = AreaInfo.PopulationDensity(
+                level = determineDensityLevel(latestData),
+                residentRate = latestData.residentPopulationRate,
+                nonResidentRate = latestData.nonResidentPopulationRate
+            ),
+            demographicInsight = AreaInfo.DemographicInsight(
+                genderRatio = AreaInfo.GenderRatio(
+                    maleRate = latestData.malePopulationRate,
+                    femaleRate = latestData.femalePopulationRate
+                ),
+                ageDistribution = AreaInfo.AgeDistribution(
+                    under10Rate = latestData.populationRate0,
+                    age10sRate = latestData.populationRate10,
+                    age20sRate = latestData.populationRate20,
+                    age30sRate = latestData.populationRate30,
+                    age40sRate = latestData.populationRate40,
+                    age50sRate = latestData.populationRate50,
+                    age60sRate = latestData.populationRate60,
+                    over70sRate = latestData.populationRate70,
+                    dominantAgeGroup = dominantAgeGroup
+                ),
+                mainVisitorGroup = mainVisitorGroup
+            ),
+            peakTimes = peakTimes,
+            lastUpdatedAt = latestData.populationUpdateTime
+        )
+    }
+    
+    /**
+     * 여러 지역 ID 목록에 대한 인구 데이터 인사이트를 도출합니다.
+     */
+    override suspend fun findPopulationInsightsByAreaIds(areaIds: List<AreaId>): List<AreaInfo.PopulationInsight> {
+        if (areaIds.isEmpty()) return emptyList()
+        
+        val result = mutableListOf<AreaInfo.PopulationInsight>()
+        for (areaId in areaIds) {
+            findPopulationInsightByAreaId(areaId)?.let { result.add(it) }
+        }
+        return result
+    }
+    
+    /**
+     * 예측 데이터에서 피크 타임 정보를 추출합니다.
+     */
+    private fun extractPeakTimes(forecastData: List<ForecastPopulation>): List<AreaInfo.PeakTimeInfo> {
+        if (forecastData.isEmpty()) return emptyList()
+        
+        // 예측 데이터를 인구 수 기준으로 내림차순 정렬
+        val sortedData = forecastData.sortedByDescending { it.forecastPopulationMax }
+        
+        // 상위 3개 시간대 선택 (또는 데이터가 3개 미만이면 모든 데이터)
+        val topPeakHours = sortedData.take(3)
+        
+        return topPeakHours.map { forecast ->
+            val hour = forecast.forecastTime.atZone(ZoneId.systemDefault()).hour
+            AreaInfo.PeakTimeInfo(
+                hour = hour,
+                expectedCongestion = determineCongestionLevel(forecast.forecastPopulationMax),
+                populationEstimate = (forecast.forecastPopulationMin + forecast.forecastPopulationMax) / 2
+            )
+        }
+    }
+    
+    /**
+     * 인구 수를 기반으로 혼잡도 수준을 결정합니다.
+     */
+    private fun determineCongestionLevel(population: Int): String {
+        return when {
+            population < 500 -> "여유"
+            population < 1000 -> "보통"
+            population < 2000 -> "혼잡"
+            else -> "매우 혼잡"
+        }
+    }
+    
+    /**
+     * 인구 밀집도 수준을 결정합니다.
+     */
+    private fun determineDensityLevel(data: AreaPopulationEntity): String {
+        // 기존 혼잡도 레벨을 기반으로 밀집도 결정
+        return when (data.congestionLevel) {
+            "여유", "보통" -> "낮음"
+            "약간 붐빔" -> "보통"
+            "붐빔" -> "높음"
+            "매우 붐빔" -> "매우 높음"
+            else -> "보통"
+        }
+    }
+    
+    /**
+     * 연령대와 성별 정보를 바탕으로 주요 방문자 그룹을 결정합니다.
+     */
+    private fun determineMainVisitorGroup(data: AreaPopulationEntity): String {
+        // 주요 연령대 (가장 비율이 높은 연령대)
+        val dominantAge = determineDominantAgeGroup(data)
+        
+        // 주요 성별 (비율이 더 높은 성별)
+        val dominantGender = if (data.malePopulationRate > data.femalePopulationRate) "남성" else "여성"
+        
+        return "$dominantAge $dominantGender"
+    }
+    
+    /**
+     * 가장 비율이 높은 연령대를 결정합니다.
+     */
+    private fun determineDominantAgeGroup(data: AreaPopulationEntity): String {
+        val ageRates = mapOf(
+            "10대 미만" to data.populationRate0,
+            "10대" to data.populationRate10,
+            "20대" to data.populationRate20,
+            "30대" to data.populationRate30,
+            "40대" to data.populationRate40,
+            "50대" to data.populationRate50,
+            "60대" to data.populationRate60,
+            "70대 이상" to data.populationRate70
+        )
+        
+        return ageRates.maxByOrNull { it.value }?.key ?: "알 수 없음"
+    }
 
     private suspend fun loadEntityById(id: AreaPopulationId): AreaPopulationEntity? =
         entityTemplate

--- a/src/main/kotlin/com/wheretopop/infrastructure/chat/AiChatAssistant.kt
+++ b/src/main/kotlin/com/wheretopop/infrastructure/chat/AiChatAssistant.kt
@@ -3,8 +3,10 @@ package com.wheretopop.infrastructure.chat
 import com.wheretopop.shared.exception.toException
 import com.wheretopop.shared.response.ErrorCode
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.reactive.asFlow
+import mu.KotlinLogging
 import org.springframework.ai.chat.client.ChatClient
 import org.springframework.ai.chat.messages.Message
 import org.springframework.ai.chat.model.ChatResponse
@@ -12,82 +14,130 @@ import org.springframework.ai.chat.prompt.ChatOptions
 import org.springframework.ai.chat.prompt.Prompt
 import org.springframework.stereotype.Component
 
-
+private val logger = KotlinLogging.logger {}
 
 @Component
 class AiChatAssistant(private val chatClient: ChatClient) : ChatAssistant {
 
-    override suspend fun call(userPrompt: String): String =
-        chatClient.prompt().user(userPrompt)
-            .call().content() ?: throw ErrorCode.CHAT_NULL_RESPONSE.toException()
+    override suspend fun call(userPrompt: String): String {
+        logger.info { "call(userPrompt: String) - User prompt: $userPrompt" }
+        logger.debug { "Calling AI model..." }
+        val response = chatClient.prompt().user(userPrompt)
+            .call().content()
+        logger.debug { "Received AI response." }
+        return response ?: throw ErrorCode.CHAT_NULL_RESPONSE.toException()
+    }
 
     override suspend fun call(systemPrompt: String?, userPrompt: String): String {
+        logger.info { "call(systemPrompt: String?, userPrompt: String) - System prompt: $systemPrompt, User prompt: $userPrompt" }
         val spec = chatClient.prompt().apply {
             systemPrompt?.let { system(it) }
             user(userPrompt)
         }
-        return spec.call().content() ?: throw ErrorCode.CHAT_NULL_RESPONSE.toException()
+        logger.debug { "Calling AI model..." }
+        val response = spec.call().content()
+        logger.debug { "Received AI response." }
+        return response ?: throw ErrorCode.CHAT_NULL_RESPONSE.toException()
     }
 
-    override suspend fun call(prompt: Prompt): String =
-        chatClient.prompt(prompt).call().content() ?: throw ErrorCode.CHAT_NULL_RESPONSE.toException()
+    override suspend fun call(prompt: Prompt): String {
+        logger.info { "call(prompt: Prompt) - Prompt contents: ${prompt.contents}" }
+        logger.debug { "Calling AI model..." }
+        val response = chatClient.prompt(prompt).call().content()
+        logger.debug { "Received AI response." }
+        return response ?: throw ErrorCode.CHAT_NULL_RESPONSE.toException()
+    }
 
     override suspend fun call(messages: List<Message>, options: ChatOptions?): String {
+        logger.info { "call(messages: List<Message>, options: ChatOptions?) - Messages count: ${messages.size}, Options: $options" }
         val spec = chatClient.prompt().apply {
             messages(messages)
             options?.let { options(it) }
         }
-        return spec.call().content() ?: throw ErrorCode.CHAT_NULL_RESPONSE.toException()
+        logger.debug { "Calling AI model..." }
+        val response = spec.call().content()
+        logger.debug { "Received AI response." }
+        return response ?: throw ErrorCode.CHAT_NULL_RESPONSE.toException()
     }
 
-    override suspend fun callWithResponse(userPrompt: String): ChatResponse =
-        chatClient.prompt().user(userPrompt)
-            .call().chatResponse() ?: throw ErrorCode.CHAT_NULL_RESPONSE.toException()
+    override suspend fun callWithResponse(userPrompt: String): ChatResponse {
+        logger.info { "callWithResponse(userPrompt: String) - User prompt: $userPrompt" }
+        logger.debug { "Calling AI model for ChatResponse..." }
+        val chatResponse = chatClient.prompt().user(userPrompt)
+            .call().chatResponse()
+        logger.debug { "Received AI ChatResponse." }
+        return chatResponse ?: throw ErrorCode.CHAT_NULL_RESPONSE.toException()
+    }
 
     override suspend fun callWithResponse(systemPrompt: String?, userPrompt: String): ChatResponse {
+        logger.info { "callWithResponse(systemPrompt: String?, userPrompt: String) - System prompt: $systemPrompt, User prompt: $userPrompt" }
         val spec = chatClient.prompt().apply {
             systemPrompt?.let { system(it) }
             user(userPrompt)
         }
-        return spec.call().chatResponse() ?: throw ErrorCode.CHAT_NULL_RESPONSE.toException()
+        logger.debug { "Calling AI model for ChatResponse..." }
+        val chatResponse = spec.call().chatResponse()
+        logger.debug { "Received AI ChatResponse." }
+        return chatResponse ?: throw ErrorCode.CHAT_NULL_RESPONSE.toException()
     }
 
-    override suspend fun callWithResponse(prompt: Prompt): ChatResponse =
-        chatClient.prompt(prompt).call().chatResponse() ?: throw ErrorCode.CHAT_NULL_RESPONSE.toException()
+    override suspend fun callWithResponse(prompt: Prompt): ChatResponse {
+        logger.info { "callWithResponse(prompt: Prompt) - Prompt contents: ${prompt.contents}" }
+        logger.debug { "Calling AI model for ChatResponse..." }
+        val chatResponse = chatClient.prompt(prompt).call().chatResponse()
+        logger.debug { "Received AI ChatResponse." }
+        return chatResponse ?: throw ErrorCode.CHAT_NULL_RESPONSE.toException()
+    }
 
     override suspend fun callWithResponse(messages: List<Message>, options: ChatOptions?): ChatResponse {
+        logger.info { "callWithResponse(messages: List<Message>, options: ChatOptions?) - Messages count: ${messages.size}, Options: $options" }
         val spec = chatClient.prompt().apply {
             messages(messages)
             options?.let { options(it) }
         }
-        return spec.call().chatResponse() ?: throw ErrorCode.CHAT_NULL_RESPONSE.toException()
+        logger.debug { "Calling AI model for ChatResponse..." }
+        val chatResponse = spec.call().chatResponse()
+        logger.debug { "Received AI ChatResponse." }
+        return chatResponse ?: throw ErrorCode.CHAT_NULL_RESPONSE.toException()
     }
 
     @ExperimentalStream
-    override suspend fun stream(userPrompt: String): Flow<ChatResponse> = flow {
-        chatClient.prompt().user(userPrompt)
-            .stream().chatResponse().asFlow().collect { emit(it) }
+    override suspend fun stream(userPrompt: String): Flow<ChatResponse> {
+        logger.info { "stream(userPrompt: String) - User prompt: $userPrompt" }
+        return chatClient.prompt().user(userPrompt)
+            .stream().chatResponse().asFlow()
+            .onStart { logger.debug { "AI stream started for user prompt: $userPrompt" } }
+            .onCompletion { logger.debug { "AI stream completed for user prompt: $userPrompt" } }
     }
 
     @ExperimentalStream
-    override suspend fun stream(systemPrompt: String?, userPrompt: String): Flow<ChatResponse> = flow {
-        chatClient.prompt().apply {
+    override suspend fun stream(systemPrompt: String?, userPrompt: String): Flow<ChatResponse> {
+        logger.info { "stream(systemPrompt: String?, userPrompt: String) - System prompt: $systemPrompt, User prompt: $userPrompt" }
+        return chatClient.prompt().apply {
             systemPrompt?.let { system(it) }
             user(userPrompt)
-        }.stream().chatResponse().asFlow().collect { emit(it) }
+        }.stream().chatResponse().asFlow()
+            .onStart { logger.debug { "AI stream started for user prompt: $userPrompt" } }
+            .onCompletion { logger.debug { "AI stream completed for user prompt: $userPrompt" } }
     }
 
     @ExperimentalStream
-    override suspend fun stream(prompt: Prompt): Flow<ChatResponse> = flow {
-        chatClient.prompt(prompt)
-            .stream().chatResponse().asFlow().collect { emit(it) }
+    override suspend fun stream(prompt: Prompt): Flow<ChatResponse> {
+        logger.info { "stream(prompt: Prompt) - Prompt contents: ${prompt.contents}" }
+        return chatClient.prompt(prompt)
+            .stream().chatResponse().asFlow()
+            .onStart { logger.debug { "AI stream started for prompt: ${prompt.contents}" } }
+            .onCompletion { logger.debug { "AI stream completed for prompt: ${prompt.contents}" } }
     }
 
     @ExperimentalStream
-    override suspend fun stream(messages: List<Message>, options: ChatOptions?): Flow<ChatResponse> = flow {
-        chatClient.prompt().apply {
+    override suspend fun stream(messages: List<Message>, options: ChatOptions?): Flow<ChatResponse> {
+        logger.info { "stream(messages: List<Message>, options: ChatOptions?) - Messages count: ${messages.size}, Options: $options" }
+        return chatClient.prompt().apply {
             messages(messages)
             options?.let { options(it) }
-        }.stream().chatResponse().asFlow().collect { emit(it) }
+        }.stream().chatResponse().asFlow()
+            .onStart { logger.debug { "AI stream started for messages count: ${messages.size}" } }
+            .onCompletion { logger.debug { "AI stream completed for messages count: ${messages.size}" } }
     }
 }

--- a/src/main/kotlin/com/wheretopop/infrastructure/chat/prompt/ConversationPromptStrategy.kt
+++ b/src/main/kotlin/com/wheretopop/infrastructure/chat/prompt/ConversationPromptStrategy.kt
@@ -5,40 +5,72 @@ import org.springframework.ai.chat.prompt.Prompt
 import org.springframework.stereotype.Component
 
 /**
- * 일반 대화를 위한 프롬프트 전략
+ * 사용자의 요청을 이해하고, 적절한 도구를 활용하여 팝업 스토어 장소 추천을 돕는 AI 어시스턴트의 프롬프트 전략.
+ * 단계적 사고와 능동적인 Tool Chaining을 통해 사용자 목표 달성을 지원한다.
  */
 @Component
 class ConversationPromptStrategy : ChatPromptStrategy {
     private val requirements = setOf(
         PromptContextRequirement.CHAT,
-        PromptContextRequirement.USER_MESSAGE
+        PromptContextRequirement.USER_MESSAGE,
     )
 
     override fun getRequirements(): Set<PromptContextRequirement> = requirements
 
     override fun canHandle(context: PromptContext): Boolean {
-        return context.chat.messages.isNotEmpty() && 
-               context.message?.role == ChatMessageRole.USER
+        // 사용자 메시지가 있을 때 이 전략을 사용
+        return context.message?.role == ChatMessageRole.USER
     }
 
     override suspend fun buildPrompt(context: PromptContext): Prompt {
         require(canHandle(context)) { "Context requirements not met for ConversationPromptStrategy" }
 
-        val messagePrefix = when (context.message?.role) {
-            ChatMessageRole.SYSTEM -> "시스템 지시사항"
-            ChatMessageRole.USER -> "사용자 메시지"
-            ChatMessageRole.ASSISTANT -> "어시스턴트 응답"
-            else -> "메시지"
+        val systemInstructions = """
+        당신은 사용자가 최적의 팝업 스토어 위치를 찾도록 돕는 전문 AI 어시스턴트 'PopVision'입니다.
+        당신의 주요 목표는 사용자의 요구사항을 정확히 파악하고, 제공된 도구(Tools)를 효과적으로 활용하여 최적의 장소를 추천하는 것입니다.
+
+        **작업 수행 가이드라인:**
+        1.  **요청 이해 및 명확화:**
+            *   사용자의 현재 요청을 이전 대화 맥락과 함께 깊이 이해합니다. 모호한 부분이 있다면, 명확한 답변을 위해 구체적인 질문을 하세요.
+            *   **자연어 이해**: 사용자가 지역명이나 특정 장소를 자연어로 언급하면, 이전에 조회된 지역 목록(예: 'findAllArea' 도구 사용 결과)에서 해당 이름과 가장 일치하거나 유사한 지역을 **내부적으로 찾아 그 지역의 식별자(ID)로 변환**하여 관련 도구를 사용하세요. 사용자에게 식별자(ID)를 직접 다시 묻기 전에 반드시 이 추론 과정을 먼저 수행해야 합니다. 정확한 매칭이 어렵다면, 가능한 후보들을 제시하며 사용자에게 선택을 요청하거나, 정중하게 다시 문의할 수 있습니다.
+
+        2.  **정보 수집 계획 (Tool Chaining):**
+            *   사용자의 요청을 해결하기 위해 어떤 정보가 필요한지 판단합니다.
+            *   필요한 정보를 얻기 위해 어떤 도구를 어떤 순서로 사용해야 할지 계획을 세웁니다.
+            *   각 도구 사용 전에 어떤 정보를 얻기 위해 이 도구를 사용하는지 명확히 인지합니다.
+
+        3.  **능동적 도구 사용 및 결과 분석:** 계획에 따라 도구를 사용하고, 그 결과를 분석하여 다음 단계를 진행합니다. 도구 사용 결과가 기대와 다르거나 정보가 부족하다면, 추가적인 도구 사용을 고려하거나 사용자에게 상황을 설명하고 대안을 제시하세요.
+
+        4.  **결론 및 제안:** 수집된 정보와 분석 결과를 바탕으로 사용자에게 명확한 결론과 함께 다음 행동을 제안합니다.
+
+        5.  **대화 흐름 및 사용자 경험:**
+            *   항상 이전 대화 내용을 기억하고, 자연스럽게 대화를 이어가세요.
+            *   **Tool 사용 비공개**: 사용자에게 응답할 때, 내부적으로 사용하는 Tool의 이름이나 식별자(ID)와 같은 구체적인 기술적 세부 정보를 직접 언급하지 마세요. 대신, Tool 사용의 목적이나 결과를 자연스러운 대화 형태로 전달하세요. (예: "관심 있는 지역을 말씀해주시면 자세히 알아볼게요." 또는 "팝업 스토어에 적합한 장소를 추천해 드릴까요?")
+            *   사용자가 이전 답변에 대해 추가 질문을 하면 성실히 답변해주세요.
+
+        **응답 형식:**
+        - 사용자에게 친절하고 명확한 어투를 사용합니다.
+        - 추천이나 분석 결과를 제시할 때는 그 근거를 함께 설명합니다.
+        - 필요한 경우, 사용자에게 선택지를 제공하여 의사결정을 돕습니다.
+        """
+
+        val conversationHistory = context.chat.messages.joinToString("\n") {
+            "${it.role}: ${it.content}"
         }
 
+        val currentUserMessage = "${context.message?.role}: ${context.message?.content}"
+
+        // 최종 프롬프트 구성
         return Prompt("""
-            이전 대화 기록을 참고하여 자연스럽게 응답해주세요.
-            
-            대화 기록:
-            ${context.chat.messages.joinToString("\n") { "${it.role}: ${it.content}" }}
-            
-            $messagePrefix:
-            ${context.message?.role}: ${context.message?.content}
+        $systemInstructions
+
+        **이전 대화 기록:**
+        $conversationHistory
+
+        **현재 사용자 요청:**
+        $currentUserMessage
+
+        **PopVision의 응답:**
         """.trimIndent())
     }
 } 

--- a/src/main/kotlin/com/wheretopop/interfaces/area/AreaApiRouter.kt
+++ b/src/main/kotlin/com/wheretopop/interfaces/area/AreaApiRouter.kt
@@ -51,7 +51,7 @@ class AreaHandler(private val areaFacade: AreaFacade) {
             limit = request.queryParam("limit").map { it.toInt() }.orElse(20)
         )
         val criteria = areaDtoMapper.toCriteria(searchRequest)
-        val domainResults = areaFacade.searchAreas(criteria)
+        val domainResults = areaFacade.findAll()
         val response = areaDtoMapper.toAreaResponses(domainResults)
 
         return ServerResponse.ok()

--- a/src/main/kotlin/com/wheretopop/interfaces/area/AreaToolRegistry.kt
+++ b/src/main/kotlin/com/wheretopop/interfaces/area/AreaToolRegistry.kt
@@ -1,0 +1,175 @@
+package com.wheretopop.interfaces.area
+
+import com.wheretopop.application.area.AreaFacade
+import com.wheretopop.domain.area.AreaId
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.runBlocking
+import mu.KotlinLogging
+import org.springframework.ai.tool.annotation.Tool
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.stereotype.Component
+import java.util.concurrent.Executors
+import javax.annotation.PreDestroy
+
+/**
+ * 지역 정보 검색을 위한 AI 도구 레지스트리입니다.
+ * Spring AI의 Tool Calling 기능을 활용하여 지역 데이터를 JSON 형태로 제공합니다.
+ */
+@Component
+class AreaToolRegistry(
+    private val areaFacade: AreaFacade,
+    private val toolDispatcher: kotlinx.coroutines.CoroutineDispatcher
+) {
+    private val logger = KotlinLogging.logger {}
+
+    /**
+     * 모든 지역 정보를 조회합니다.
+     * AI 모델이 사용자에게 전체 지역 목록이 필요할 때 이 도구를 호출합니다.
+     * 
+     * @return 모든 지역 정보가 포함된 JSON 문자열
+     */
+    @Tool(description = "모든 지역 정보를 조회합니다. 사용자가 전체 지역 목록이나 지역 데이터를 요청할 때 사용하세요.")
+    fun findAllArea(): String {
+        logger.info("findAllArea 도구가 호출되었습니다")
+        
+        // 별도의 쓰레드 풀에서 suspend 함수 호출
+        val areas = runBlocking(toolDispatcher) {
+            logger.info("별도 쓰레드에서 코루틴 실행 중 - findAllArea")
+            areaFacade.findAll()
+        }
+        
+        logger.info("총 ${areas.size}개 지역 정보를 조회했습니다")
+        
+        return """
+        {
+            "status": "success",
+            "count": ${areas.size},
+            "areas": [
+                ${areas.joinToString(",\n") { area ->
+                    """
+                    {
+                        "id": "${area.id}",
+                        "name": "${area.name}",
+                        "description": "${area.description?.replace("\"", "\\\"") ?: ""}",
+                        "location": {
+                            "latitude": ${area.location.latitude},
+                            "longitude": ${area.location.longitude}
+                        }
+                    }
+                    """.trimIndent()
+                }}
+            ]
+        }
+        """.trimIndent()
+    }
+
+    /**
+     * 특정 ID에 해당하는 지역의 상세 정보를 조회합니다.
+     * AI 모델이 특정 지역에 대한 상세 정보가 필요할 때 이 도구를 호출합니다.
+     * 
+     * @param id 조회할 지역의 ID
+     * @return 해당 지역의 상세 정보가 포함된 JSON 문자열
+     */
+    @Tool(description = "ID로 특정 지역의 상세 정보를 조회합니다. 사용자가 특정 지역의 상세 정보, 인구 통계, 혼잡도 등을 요청할 때 사용하세요.")
+    fun findAreaById(id: String): String {
+        logger.info("findAreaById 도구가 호출되었습니다: id={}", id)
+        
+        // 별도의 쓰레드 풀에서 suspend 함수 호출
+        val area = runBlocking(toolDispatcher) {
+            logger.info("별도 쓰레드에서 코루틴 실행 중 - findAreaById")
+            areaFacade.getAreaDetailById(AreaId.of(id))
+        }
+        
+        if (area == null) {
+            logger.warn("ID가 {}인 지역을 찾을 수 없습니다", id)
+            return """
+            {
+                "status": "error",
+                "message": "해당 ID를 가진 지역을 찾을 수 없습니다: $id"
+            }
+            """.trimIndent()
+        }
+        
+        logger.info("ID {}에 해당하는 지역 정보를 성공적으로 조회했습니다: {}", id, area.name)
+        
+        return """
+        {
+            "status": "success",
+            "area": {
+                "id": "${area.id}",
+                "name": "${area.name}",
+                "description": "${area.description?.replace("\"", "\\\"") ?: ""}",
+                "location": {
+                    "latitude": ${area.location.latitude},
+                    "longitude": ${area.location.longitude}
+                },
+                "populationInsight": {
+                    "areaId": "${area.populationInsight?.areaId ?: ""}",
+                    "areaName": "${area.populationInsight?.areaName ?: ""}",
+                    "congestionLevel": "${area.populationInsight?.congestionLevel ?: ""}",
+                    "congestionMessage": "${area.populationInsight?.congestionMessage?.replace("\"", "\\\"") ?: ""}",
+                    "currentPopulation": ${area.populationInsight?.currentPopulation ?: 0},
+                    "populationDensity": {
+                        "level": "${area.populationInsight?.populationDensity?.level ?: ""}",
+                        "residentRate": ${area.populationInsight?.populationDensity?.residentRate ?: 0.0},
+                        "nonResidentRate": ${area.populationInsight?.populationDensity?.nonResidentRate ?: 0.0}
+                    },
+                    "lastUpdatedAt": "${area.populationInsight?.lastUpdatedAt ?: ""}"
+                }
+            }
+        }
+        """.trimIndent()
+    }
+
+    /**
+     * 위치(좌표) 기반으로 가장 가까운 지역을 찾습니다.
+     * AI 모델이 사용자의 현재 위치에 가까운 지역을 찾을 때 사용합니다.
+     * 
+     * @param latitude 위도
+     * @param longitude 경도
+     * @return 가장 가까운 지역 정보가 포함된 JSON 문자열
+     */
+    @Tool(description = "위도와 경도를 기반으로 가장 가까운 지역을 찾습니다. 사용자가 현재 위치 주변 지역이나 특정 좌표 근처의 지역을 알고 싶을 때 사용하세요.")
+    fun findNearestArea(latitude: Double, longitude: Double): String {
+        logger.info("findNearestArea 도구가 호출되었습니다: latitude={}, longitude={}", latitude, longitude)
+        
+        // 실제 구현은 areaFacade에 추가 기능이 필요합니다.
+        // 아래는 예시 응답 형식입니다.
+        return """
+        {
+            "status": "success",
+            "message": "가장 가까운 지역을 찾았습니다",
+            "area": {
+                "id": "sample-id",
+                "name": "샘플 지역",
+                "description": "이 기능은 아직 구현되지 않았습니다",
+                "distance": "0.5km",
+                "location": {
+                    "latitude": $latitude,
+                    "longitude": $longitude
+                }
+            }
+        }
+        """.trimIndent()
+    }
+}
+
+/**
+ * Spring AI Tool 호출을 위한 코루틴 디스패처 설정
+ * WebFlux 환경에서 안전하게 suspend 함수를 호출하기 위한 별도의 쓰레드 풀을 제공합니다.
+ */
+@Configuration
+class ToolDispatcherConfig {
+    private val logger = KotlinLogging.logger {}
+    
+    @Bean(destroyMethod = "close")
+    fun toolDispatcher() = Executors.newFixedThreadPool(4).asCoroutineDispatcher().also {
+        logger.info("Spring AI Tool 전용 코루틴 디스패처가 생성되었습니다.")
+    }
+    
+    @PreDestroy
+    fun cleanup() {
+        logger.info("Spring AI Tool 전용 코루틴 디스패처 리소스를 정리합니다.")
+    }
+}


### PR DESCRIPTION
area 서치 기능을 구현하고, Spring AI의 Tool 기능을 활용한 function calling 기반 테스트 및 기술 검증을 진행함.

---

### 발생한 이슈

* Spring AI의 `@Tool` 기반 function calling은 `suspend` 함수나 `Flow`와 같은 비동기 코루틴 타입을 지원하지 않음.
* WebFlux 기반 애플리케이션에서 `runBlocking`을 사용할 경우, 해당 코드가 Reactor의 event loop thread (`*-worker-*`)에서 실행되면 block이 발생함. 이로 인해 데드락 상황이 비결정적으로 발생함.
* 단순히 `runBlocking(Dispatchers.IO)`을 사용해도, 실행되는 스레드가 Reactor thread일 경우 문제는 해결되지 않음. block 자체는 여전히 Reactor 스레드에서 발생하기 때문.

→ 이 문제를 회피하기 위해, tool 내부에서 `runBlocking`을 안전하게 실행할 수 있도록 별도의 `CoroutineDispatcher`를 생성하여 스레드를 명시적으로 분리함.

```kotlin
private val toolDispatcher: CoroutineDispatcher = Executors.newSingleThreadExecutor().asCoroutineDispatcher()
```

이 dispatcher를 통해 도구 함수 내부에서 `runBlocking(toolDispatcher)` 방식으로 코루틴을 호출함. 실행 스레드가 Reactor의 event loop가 아닌 독립된 스레드이므로 blocking이 허용됨.

---

### 향후 고려할 점

* 현재는 "모든 지역 목록"과 같이 리스트성 정보를 조회하는 툴에 대해서는 문제없이 function calling이 동작함.
* 하지만, 향후 "ID 기반 조회" 기능을 function calling 체인에서 사용하려 할 때 문제가 발생할 수 있음.
* 예컨대 LLM이 첫 번째 요청에서는 ID가 포함된 리스트 조회 tool을 사용하고, 후속 질의에서 특정 ID로 세부 정보를 요청하려 할 경우:

  * 후속 질의의 context에 ID 정보가 포함되어 있지 않으면, LLM이 해당 도구를 어떤 ID로 호출해야 할지 판단하지 못함.
  * 이는 LLM이 응답에서 ID를 명시적으로 포함하지 않는 경우 특히 문제가 되며, tool chaining을 설계할 때 context persistence가 필요함.

→ ID 등 중요한 context 정보를 명시적으로 memory에 남기거나, 이전 응답을 기반으로 reasoning이 가능하도록 prompt 구조 설계가 필요함. spring-ai-memory를 이용한 명시적 context 관리도 고려 대상임.
