### PR TITLE
Vector DB Object Class 분리 및 Popup 데이터 업데이트 오류 수정

### DIFF
--- a/src/main/kotlin/com/wheretopop/application/popup/PopupFacade.kt
+++ b/src/main/kotlin/com/wheretopop/application/popup/PopupFacade.kt
@@ -50,7 +50,7 @@ class PopupFacade(
 //            if (popplyUseCase.isPopupInfoPersisted(basicPopupInfo.id.value)) return@forEach
 
             if (basicPopupInfo.latitude == null || basicPopupInfo.longitude == null) return@forEach
-            val areaFound = areaService.searchNearest(
+            val areaFound = areaService.findNearestArea(
                 basicPopupInfo.latitude,
                 basicPopupInfo.longitude,
             )

--- a/src/main/kotlin/com/wheretopop/config/VectorStoreConfig.kt
+++ b/src/main/kotlin/com/wheretopop/config/VectorStoreConfig.kt
@@ -23,8 +23,11 @@ class VectorStoreConfig(
     @Value("\${spring.ai.vectorstore.weaviate.port:8081}")
     private var port: Int = 0
 
-    @Value("\${spring.ai.vectorstore.weaviate.object-class:PopupStore}")
-    private lateinit var objectClass: String
+    @Value("\${spring.ai.vectorstore.weaviate.object-class.popup:PopupStore}")
+    private lateinit var popupObjectClass: String
+
+    @Value("\${spring.ai.vectorstore.weaviate.object-class.long-term-memory:LongTermMemory}")
+    private lateinit var longTermMemoryObjectClass: String
 
     @Bean
     fun weaviateClient(): WeaviateClient {
@@ -32,14 +35,25 @@ class VectorStoreConfig(
         return WeaviateClient(Config(scheme, fullHost))
     }
 
-    @Bean(name = ["customVectorStore"])
-    fun vectorStore(
+    @Bean(name = ["popupVectorStore"])
+    fun popupVectorStore(
         weaviateClient: WeaviateClient,
         embeddingModel: EmbeddingModel,
     ): VectorStore {
         return WeaviateVectorStore
             .builder(weaviateClient, embeddingModel)
-            .objectClass(objectClass)
+            .objectClass(popupObjectClass)
+            .build()
+    }
+
+    @Bean(name = ["longTermMemoryVectorStore"])
+    fun longTermMemoryVectorStore(
+        weaviateClient: WeaviateClient,
+        embeddingModel: EmbeddingModel,
+    ): VectorStore {
+        return WeaviateVectorStore
+            .builder(weaviateClient, embeddingModel)
+            .objectClass(longTermMemoryObjectClass)
             .build()
     }
 }

--- a/src/main/kotlin/com/wheretopop/infrastructure/popup/external/PopupVectorRepositoryImpl.kt
+++ b/src/main/kotlin/com/wheretopop/infrastructure/popup/external/PopupVectorRepositoryImpl.kt
@@ -7,6 +7,7 @@ import mu.KotlinLogging
 import org.springframework.ai.document.Document
 import org.springframework.ai.vectorstore.SearchRequest
 import org.springframework.ai.vectorstore.VectorStore
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Repository
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import java.util.concurrent.TimeUnit
@@ -15,6 +16,7 @@ private val logger = KotlinLogging.logger {}
 
 @Repository
 class PopupVectorRepositoryImpl(
+    @Qualifier("popupVectorStore")
     private val vectorStore: VectorStore
 ): PopupVectorRepository {
     override fun addPopupInfo(popupInfo: PopupInfo.Detail) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -75,7 +75,9 @@ spring:
         scheme: ${VECTOR_DB_SCHEME:http}
         host: ${VECTOR_DB_HOST:localhost}
         port: ${VECTOR_DB_PORT:8081}
-        object-class: PopupStore
+        object-class:
+          popup: PopupStore
+          long-term-memory: LongTermMemory
 
 openapi:
   seoul:


### PR DESCRIPTION
### 1. ObjectClass 분리
- ObjectClass를 PopupStore와 LongTermMemory 두 개로 분리했습니다.
- 사용 시 @Qualifier를 통해 원하는 ObjectClass를 선택하여 사용할 수 있도록 구성했습니다.

### 2. 좌표 기반 Area 탐색 함수 수정
- 기존 함수를 도훈님이 작성하신 DB 기반 로직으로 교체했습니다.