### PR TITLE
Fix query usage in PopupVectorRepository

### DIFF
--- a/src/main/kotlin/com/wheretopop/infrastructure/popup/external/PopupVectorRepositoryImpl.kt
+++ b/src/main/kotlin/com/wheretopop/infrastructure/popup/external/PopupVectorRepositoryImpl.kt
@@ -156,7 +156,7 @@ class PopupVectorRepositoryImpl(
 
     override fun findByCategory(category: String, query: String, k: Int): List<Document> {
         val filterExp = "category == '$category'"
-        val request = SearchRequest.builder().query(category).topK(k).filterExpression(filterExp).build()
+        val request = SearchRequest.builder().query(query).topK(k).filterExpression(filterExp).build()
         return safeSearch(request)
     }
 }


### PR DESCRIPTION
## Summary
- ensure findByCategory passes user query instead of category value

## Testing
- `./gradlew test --no-daemon` *(fails: could not complete due to missing dependencies)*


------
https://chatgpt.com/codex/tasks/task_e_68467ed9aaac8331af134ef504b1ea3c