### PR TITLE
Set up CI with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: gradle
+      - name: Build and Test
+        run: ./gradlew build --no-daemon

--- a/README.md
+++ b/README.md
@@ -57,3 +57,7 @@ API 문서는 애플리케이션 실행 후 다음 URL에서 확인할 수 있�
 - Elasticsearch: `localhost:9200`
 - Kibana: `localhost:5601`
 - DBGate: `localhost:3000`
+
+## CI
+
+이 저장소는 GitHub Actions로 테스트를 자동 실행하도록 설정되어 있습니다. 변경 사항이 `main` 브랜치에 push되거나 Pull Request가 생성되면 워크플로가 실행되어 Gradle 빌드와 테스트를 수행합니다.


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to run Gradle build
- document CI setup in README

## Testing
- `./gradlew test --no-daemon` *(fails: Task :checkKotlinGradlePluginConfigurationErrors)*

------
https://chatgpt.com/codex/tasks/task_e_68467f0530048331aadfa6355a500b29